### PR TITLE
fix: correct table names and RLS policies for dashboard stat counters

### DIFF
--- a/apps/web/app/(dashboard)/dashboard/assessments/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/assessments/page.tsx
@@ -261,14 +261,14 @@ export default function AssessmentsPage() {
         useCases.map(async (uc) => {
           const { data: obligations } = await supabase
             .from('use_case_obligations')
-            .select('status')
+            .select('is_completed')
             .eq('use_case_id', uc.id)
 
           const total = obligations?.length ?? 0
           const completed =
-            obligations?.filter((o) => o.status === 'completed').length ?? 0
+            obligations?.filter((o) => o.is_completed === true).length ?? 0
           const in_progress =
-            obligations?.filter((o) => o.status === 'in_progress').length ?? 0
+            obligations?.filter((o) => o.is_completed === false).length ?? 0
           const pct = total > 0 ? Math.round((completed / total) * 100) : 0
 
           return {

--- a/apps/web/app/(dashboard)/dashboard/reports/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/reports/page.tsx
@@ -66,10 +66,11 @@ export default function ReportsPage() {
       const enriched: SystemForReport[] = await Promise.all(
         useCases.map(async (uc) => {
           const [{ data: obligations }, { data: risks }] = await Promise.all([
-            supabase.from('use_case_obligations').select('status').eq('use_case_id', uc.id),
-            supabase.from('ai_system_risks').select('status').eq('ai_system_id', uc.id),
+            supabase.from('use_case_obligations').select('is_completed').eq('use_case_id', uc.id),
+            supabase.from('use_case_risks').select('status, applicable').eq('use_case_id', uc.id),
           ]);
 
+          const applicableRisks = risks?.filter(r => r.applicable === true) ?? [];
           return {
             id: uc.id,
             name: uc.name,
@@ -77,9 +78,9 @@ export default function ReportsPage() {
             status: uc.status || 'draft',
             created_at: uc.created_at,
             obligations_total: obligations?.length ?? 0,
-            obligations_completed: obligations?.filter(o => o.status === 'completed').length ?? 0,
-            risks_total: risks?.length ?? 0,
-            risks_mitigated: risks?.filter(r => ['mitigated', 'accepted'].includes(r.status)).length ?? 0,
+            obligations_completed: obligations?.filter(o => o.is_completed === true).length ?? 0,
+            risks_total: applicableRisks.length,
+            risks_mitigated: applicableRisks.filter(r => r.status === 'mitigated').length,
           };
         })
       );

--- a/apps/web/app/(dashboard)/dashboard/risk/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/risk/page.tsx
@@ -253,24 +253,24 @@ export default function RiskPage() {
       const enriched: SystemRiskData[] = await Promise.all(
         useCases.map(async (uc) => {
           const { data: risks } = await supabase
-            .from('ai_system_risks')
-            .select('status, probability, impact')
-            .eq('ai_system_id', uc.id)
+            .from('use_case_risks')
+            .select('status, probability, impact, applicable')
+            .eq('use_case_id', uc.id)
 
-          const total = risks?.length ?? 0
+          const applicable = risks?.filter((r) => r.applicable === true) ?? []
+          const total = applicable.length
           const assessed =
-            risks?.filter((r) =>
+            applicable.filter((r) =>
               ['assessed', 'mitigated', 'accepted'].includes(r.status)
-            ).length ?? 0
+            ).length
           const mitigated =
-            risks?.filter((r) => ['mitigated', 'accepted'].includes(r.status))
-              .length ?? 0
+            applicable.filter((r) => r.status === 'mitigated').length
           const critical_open =
-            risks?.filter(
+            applicable.filter(
               (r) =>
                 r.probability === 'critical' &&
                 !['mitigated', 'accepted'].includes(r.status)
-            ).length ?? 0
+            ).length
           const pct = total > 0 ? Math.round((mitigated / total) * 100) : 0
 
           return {

--- a/apps/web/components/dashboard-navbar.tsx
+++ b/apps/web/components/dashboard-navbar.tsx
@@ -61,14 +61,14 @@ export function DashboardNavbar() {
         className="flex items-center hover:opacity-80 transition-opacity"
       >
         <CumpliaLogo
-          markSize={28}
-          wordSize={18}
+          markSize={30}
+          wordSize={22}
           variant="light"
           className="dark:hidden"
         />
         <CumpliaLogo
-          markSize={28}
-          wordSize={18}
+          markSize={30}
+          wordSize={22}
           variant="dark"
           className="hidden dark:inline-flex"
         />

--- a/apps/web/components/dashboard-sidebar.tsx
+++ b/apps/web/components/dashboard-sidebar.tsx
@@ -291,9 +291,9 @@ function SidebarContent({
             className="inline-flex flex-shrink-0"
           >
             {collapsed ? (
-              <Logomark size={28} variant="light" />
+              <Logomark size={30} variant="light" />
             ) : (
-              <CumpliaLogo markSize={28} wordSize={18} variant="light" />
+              <CumpliaLogo markSize={30} wordSize={22} variant="light" />
             )}
           </Link>
 
@@ -520,7 +520,7 @@ export function DashboardSidebar() {
       {/* Mobile Header with Hamburger */}
       <div className="lg:hidden fixed top-0 left-0 right-0 h-16 bg-[#FAFAF8] border-b border-[#E3DFD5] z-40 flex items-center justify-between px-4">
         <Link href="/" className="inline-flex">
-          <CumpliaLogo markSize={26} wordSize={16} variant="light" />
+          <CumpliaLogo markSize={30} wordSize={22} variant="light" />
         </Link>
 
         <Drawer open={drawerOpen} onOpenChange={setDrawerOpen}>

--- a/supabase/migrations/20260420000000_fix_risks_obligations_rls.sql
+++ b/supabase/migrations/20260420000000_fix_risks_obligations_rls.sql
@@ -1,0 +1,111 @@
+-- Migration: Fix RLS policies for use_case_risks and use_case_obligations
+-- Problem: current policies only allow access via org membership, breaking solo users
+-- Fix: allow access if the user owns the use_case (user_id match) OR is an org member
+
+-- ============================================================
+-- use_case_risks: drop org-only policies, restore user+org
+-- ============================================================
+
+DROP POLICY IF EXISTS "Users can view system risks via organization" ON use_case_risks;
+DROP POLICY IF EXISTS "Users can insert system risks via organization" ON use_case_risks;
+DROP POLICY IF EXISTS "Users can update system risks via organization" ON use_case_risks;
+DROP POLICY IF EXISTS "Users can delete system risks via organization" ON use_case_risks;
+
+DROP POLICY IF EXISTS use_case_risks_select ON use_case_risks;
+DROP POLICY IF EXISTS use_case_risks_insert ON use_case_risks;
+DROP POLICY IF EXISTS use_case_risks_update ON use_case_risks;
+DROP POLICY IF EXISTS use_case_risks_delete ON use_case_risks;
+
+CREATE POLICY "use_case_risks_select" ON use_case_risks
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM use_cases uc
+      WHERE uc.id = use_case_risks.use_case_id
+        AND (
+          uc.user_id = auth.uid()
+          OR uc.organization_id IN (SELECT get_user_org_ids(auth.uid()))
+        )
+    )
+  );
+
+CREATE POLICY "use_case_risks_insert" ON use_case_risks
+  FOR INSERT WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM use_cases uc
+      WHERE uc.id = use_case_risks.use_case_id
+        AND (
+          uc.user_id = auth.uid()
+          OR uc.organization_id IN (SELECT get_user_org_ids(auth.uid()))
+        )
+    )
+  );
+
+CREATE POLICY "use_case_risks_update" ON use_case_risks
+  FOR UPDATE USING (
+    EXISTS (
+      SELECT 1 FROM use_cases uc
+      WHERE uc.id = use_case_risks.use_case_id
+        AND (
+          uc.user_id = auth.uid()
+          OR uc.organization_id IN (SELECT get_user_org_ids(auth.uid()))
+        )
+    )
+  );
+
+CREATE POLICY "use_case_risks_delete" ON use_case_risks
+  FOR DELETE USING (
+    EXISTS (
+      SELECT 1 FROM use_cases uc
+      WHERE uc.id = use_case_risks.use_case_id
+        AND (
+          uc.user_id = auth.uid()
+          OR uc.organization_id IN (SELECT get_user_org_ids(auth.uid()))
+        )
+    )
+  );
+
+-- ============================================================
+-- use_case_obligations: replace org-only policy with user+org
+-- Solo users have organization_id = NULL so the old policy blocked them
+-- ============================================================
+
+DROP POLICY IF EXISTS "Org members can view obligations" ON use_case_obligations;
+DROP POLICY IF EXISTS "Org members can insert obligations" ON use_case_obligations;
+DROP POLICY IF EXISTS "Org members can update obligations" ON use_case_obligations;
+DROP POLICY IF EXISTS "Org members can delete obligations" ON use_case_obligations;
+
+CREATE POLICY "use_case_obligations_select" ON use_case_obligations
+  FOR SELECT USING (
+    use_case_id IN (
+      SELECT id FROM use_cases
+      WHERE user_id = auth.uid()
+        OR organization_id IN (SELECT get_user_org_ids(auth.uid()))
+    )
+  );
+
+CREATE POLICY "use_case_obligations_insert" ON use_case_obligations
+  FOR INSERT WITH CHECK (
+    use_case_id IN (
+      SELECT id FROM use_cases
+      WHERE user_id = auth.uid()
+        OR organization_id IN (SELECT get_user_org_ids(auth.uid()))
+    )
+  );
+
+CREATE POLICY "use_case_obligations_update" ON use_case_obligations
+  FOR UPDATE USING (
+    use_case_id IN (
+      SELECT id FROM use_cases
+      WHERE user_id = auth.uid()
+        OR organization_id IN (SELECT get_user_org_ids(auth.uid()))
+    )
+  );
+
+CREATE POLICY "use_case_obligations_delete" ON use_case_obligations
+  FOR DELETE USING (
+    use_case_id IN (
+      SELECT id FROM use_cases
+      WHERE user_id = auth.uid()
+        OR organization_id IN (SELECT get_user_org_ids(auth.uid()))
+    )
+  );


### PR DESCRIPTION
- risk/page.tsx, reports/page.tsx: query use_case_risks with use_case_id (not ai_system_risks/ai_system_id)
- assessments/page.tsx: select is_completed instead of non-existent status column
- reports/page.tsx: same is_completed fix plus applicable filter on risks
- risk/page.tsx: filter by applicable=true; align mitigated definition to status='mitigated' only
- Migration: fix RLS for use_case_risks and use_case_obligations to allow solo users (user_id match OR org member)
- Logo: update dashboard navbar and sidebar to markSize=30 wordSize=22 matching landing page