### PR TITLE
feat: dynamic RIA form templates for EU AI Act risk classification

### DIFF
--- a/apps/web/app/(dashboard)/dashboard/admin/components/create-ria-template-dialog.tsx
+++ b/apps/web/app/(dashboard)/dashboard/admin/components/create-ria-template-dialog.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Loader2 } from 'lucide-react';
+import type { RiaFormTemplate } from '@/types/ria-form-template';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  templates: RiaFormTemplate[];
+  onConfirm: (name: string, description: string, sourceId: string) => Promise<void>;
+}
+
+export function CreateRiaTemplateDialog({ open, onOpenChange, templates, onConfirm }: Props) {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [sourceId, setSourceId] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const systemTemplate = templates.find((t) => t.is_system);
+
+  const handleSubmit = async () => {
+    if (!name.trim()) return;
+    const resolvedSource = sourceId || systemTemplate?.id || '';
+    if (!resolvedSource) return;
+
+    setIsLoading(true);
+    try {
+      await onConfirm(name.trim(), description.trim(), resolvedSource);
+      setName('');
+      setDescription('');
+      setSourceId('');
+      onOpenChange(false);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Nueva plantilla RIA</DialogTitle>
+          <DialogDescription>
+            Crea una plantilla personalizada basándote en una existente.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-2">
+            <Label htmlFor="ria-name">Nombre *</Label>
+            <Input
+              id="ria-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Ej: Plantilla sector sanitario"
+              disabled={isLoading}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="ria-description">Descripción</Label>
+            <Textarea
+              id="ria-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Descripción opcional de la plantilla..."
+              rows={3}
+              disabled={isLoading}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="ria-source">Basada en</Label>
+            <Select value={sourceId || systemTemplate?.id || ''} onValueChange={setSourceId} disabled={isLoading}>
+              <SelectTrigger id="ria-source">
+                <SelectValue placeholder="Selecciona plantilla base..." />
+              </SelectTrigger>
+              <SelectContent>
+                {templates.map((t) => (
+                  <SelectItem key={t.id} value={t.id}>
+                    {t.name}
+                    {t.is_system ? ' (sistema)' : ''}
+                    {t.is_default && !t.is_system ? ' (predeterminada)' : ''}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isLoading}>
+            Cancelar
+          </Button>
+          <Button onClick={handleSubmit} disabled={isLoading || !name.trim()}>
+            {isLoading && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+            Crear plantilla
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/app/(dashboard)/dashboard/admin/components/ria-form-panel.tsx
+++ b/apps/web/app/(dashboard)/dashboard/admin/components/ria-form-panel.tsx
@@ -1,0 +1,314 @@
+'use client';
+
+import { useState } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import {
+  Plus,
+  Copy,
+  Trash2,
+  Star,
+  MoreVertical,
+  Lock,
+  FileText,
+  Pencil,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import { useRiaTemplates } from '@/hooks/use-ria-templates';
+import { CreateRiaTemplateDialog } from './create-ria-template-dialog';
+import { RiaTemplateEditor } from './ria-template-editor';
+import type { RiaFormTemplate, RiaFormStructure } from '@/types/ria-form-template';
+
+export function RiaFormPanel() {
+  const { templates, isLoading, error, createTemplate, updateTemplate, deleteTemplate, duplicateTemplate, setDefaultTemplate } =
+    useRiaTemplates();
+
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [editingTemplate, setEditingTemplate] = useState<RiaFormTemplate | null>(null);
+  const [templateToDelete, setTemplateToDelete] = useState<RiaFormTemplate | null>(null);
+
+  const handleCreate = async (name: string, description: string, sourceId: string) => {
+    try {
+      await createTemplate({ name, description, source_template_id: sourceId, structure: undefined as never, classification_rules: undefined as never });
+      toast.success('Plantilla creada', { description: `"${name}" ha sido creada correctamente.` });
+    } catch (err) {
+      toast.error('Error al crear', { description: err instanceof Error ? err.message : 'Error desconocido' });
+      throw err;
+    }
+  };
+
+  const handleDuplicate = async (template: RiaFormTemplate) => {
+    try {
+      const name = `${template.name} (copia)`;
+      await duplicateTemplate(template.id, name);
+      toast.success('Plantilla duplicada', { description: `"${name}" ha sido creada.` });
+    } catch (err) {
+      toast.error('Error al duplicar', { description: err instanceof Error ? err.message : 'Error desconocido' });
+    }
+  };
+
+  const handleSetDefault = async (template: RiaFormTemplate) => {
+    try {
+      await setDefaultTemplate(template.id);
+      toast.success('Plantilla predeterminada', { description: `"${template.name}" es ahora la plantilla por defecto.` });
+    } catch (err) {
+      toast.error('Error', { description: err instanceof Error ? err.message : 'Error desconocido' });
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!templateToDelete) return;
+    try {
+      await deleteTemplate(templateToDelete.id);
+      toast.success('Plantilla eliminada', { description: `"${templateToDelete.name}" ha sido eliminada.` });
+      setTemplateToDelete(null);
+    } catch (err) {
+      toast.error('Error al eliminar', { description: err instanceof Error ? err.message : 'Error desconocido' });
+    }
+  };
+
+  const handleSaveStructure = async (structure: RiaFormStructure) => {
+    if (!editingTemplate) return;
+    await updateTemplate(editingTemplate.id, { structure });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        {[1, 2, 3].map((i) => (
+          <Skeleton key={i} className="h-24 w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <p className="text-sm text-red-500">{error}</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const systemTemplate = templates.find((t) => t.is_system);
+  const customTemplates = templates.filter((t) => !t.is_system);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-semibold">Plantillas de Formulario RIA</h3>
+          <p className="text-sm text-gray-500 mt-0.5">
+            Gestiona las plantillas del formulario de evaluación de impacto.
+          </p>
+        </div>
+        <Button onClick={() => setIsCreateOpen(true)} size="sm">
+          <Plus className="w-4 h-4 mr-2" />
+          Nueva plantilla
+        </Button>
+      </div>
+
+      {systemTemplate && (
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase text-gray-400 tracking-wide">Plantilla del sistema</p>
+          <TemplateCard
+            template={systemTemplate}
+            onDuplicate={handleDuplicate}
+            onSetDefault={handleSetDefault}
+            onEdit={setEditingTemplate}
+            onDelete={setTemplateToDelete}
+          />
+        </div>
+      )}
+
+      {customTemplates.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase text-gray-400 tracking-wide">Plantillas personalizadas</p>
+          {customTemplates.map((t) => (
+            <TemplateCard
+              key={t.id}
+              template={t}
+              onDuplicate={handleDuplicate}
+              onSetDefault={handleSetDefault}
+              onEdit={setEditingTemplate}
+              onDelete={setTemplateToDelete}
+            />
+          ))}
+        </div>
+      )}
+
+      {customTemplates.length === 0 && !isLoading && (
+        <Card className="border-dashed">
+          <CardContent className="py-8 text-center">
+            <FileText className="w-8 h-8 text-gray-300 mx-auto mb-2" />
+            <p className="text-sm text-gray-500">
+              No tienes plantillas personalizadas.
+            </p>
+            <p className="text-xs text-gray-400 mt-1">
+              Crea una basándote en la plantilla del sistema o en cualquier otra existente.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      <CreateRiaTemplateDialog
+        open={isCreateOpen}
+        onOpenChange={setIsCreateOpen}
+        templates={templates}
+        onConfirm={handleCreate}
+      />
+
+      <AlertDialog open={!!templateToDelete} onOpenChange={(open) => !open && setTemplateToDelete(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>¿Eliminar plantilla?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Se eliminará permanentemente <strong>{templateToDelete?.name}</strong>. Esta acción no se puede deshacer.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction className="bg-red-600 hover:bg-red-700" onClick={handleDelete}>
+              Eliminar
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <Sheet open={!!editingTemplate} onOpenChange={(open) => !open && setEditingTemplate(null)}>
+        <SheetContent side="right" className="w-full sm:max-w-2xl overflow-y-auto">
+          {editingTemplate && (
+            <>
+              <SheetHeader className="mb-4">
+                <SheetTitle>Editar plantilla</SheetTitle>
+                <SheetDescription>{editingTemplate.name}</SheetDescription>
+              </SheetHeader>
+              <RiaTemplateEditor
+                template={editingTemplate}
+                onSave={handleSaveStructure}
+              />
+            </>
+          )}
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+}
+
+interface TemplateCardProps {
+  template: RiaFormTemplate;
+  onDuplicate: (t: RiaFormTemplate) => void;
+  onSetDefault: (t: RiaFormTemplate) => void;
+  onEdit: (t: RiaFormTemplate) => void;
+  onDelete: (t: RiaFormTemplate) => void;
+}
+
+function TemplateCard({ template, onDuplicate, onSetDefault, onEdit, onDelete }: TemplateCardProps) {
+  const stepCount = template.structure?.steps?.length ?? 0;
+  const questionCount = template.structure?.steps?.reduce(
+    (acc, step) =>
+      acc + (step.sections?.reduce((a, s) => a + s.questions.length, 0) ?? 0),
+    0
+  ) ?? 0;
+
+  return (
+    <Card className={template.is_default ? 'border-blue-200 bg-blue-50/30' : ''}>
+      <CardHeader className="py-3 px-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <CardTitle className="text-base">{template.name}</CardTitle>
+              {template.is_system && (
+                <Badge variant="secondary" className="text-xs gap-1">
+                  <Lock className="w-3 h-3" />
+                  Sistema
+                </Badge>
+              )}
+              {template.is_default && (
+                <Badge className="text-xs gap-1 bg-blue-600">
+                  <Star className="w-3 h-3" />
+                  Por defecto
+                </Badge>
+              )}
+            </div>
+            {template.description && (
+              <CardDescription className="mt-0.5 text-xs">{template.description}</CardDescription>
+            )}
+            <p className="text-xs text-gray-400 mt-1">
+              {stepCount} pasos · {questionCount} preguntas
+            </p>
+          </div>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="sm" className="h-8 w-8 p-0 shrink-0">
+                <MoreVertical className="w-4 h-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {!template.is_system && (
+                <>
+                  <DropdownMenuItem onClick={() => onEdit(template)}>
+                    <Pencil className="w-4 h-4 mr-2" />
+                    Editar estructura
+                  </DropdownMenuItem>
+                  {!template.is_default && (
+                    <DropdownMenuItem onClick={() => onSetDefault(template)}>
+                      <Star className="w-4 h-4 mr-2" />
+                      Establecer como predeterminada
+                    </DropdownMenuItem>
+                  )}
+                </>
+              )}
+              <DropdownMenuItem onClick={() => onDuplicate(template)}>
+                <Copy className="w-4 h-4 mr-2" />
+                Duplicar
+              </DropdownMenuItem>
+              {!template.is_system && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    className="text-red-600 focus:text-red-600"
+                    onClick={() => onDelete(template)}
+                    disabled={template.is_default}
+                  >
+                    <Trash2 className="w-4 h-4 mr-2" />
+                    Eliminar
+                  </DropdownMenuItem>
+                </>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </CardHeader>
+    </Card>
+  );
+}

--- a/apps/web/app/(dashboard)/dashboard/admin/components/ria-template-editor.tsx
+++ b/apps/web/app/(dashboard)/dashboard/admin/components/ria-template-editor.tsx
@@ -1,0 +1,497 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Switch } from '@/components/ui/switch';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
+  ChevronDown,
+  ChevronRight,
+  Plus,
+  Trash2,
+  GripVertical,
+  Save,
+  Loader2,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import type {
+  RiaFormTemplate,
+  RiaFormStep,
+  RiaFormSection,
+  RiaFormQuestion,
+  RiaFormStructure,
+} from '@/types/ria-form-template';
+
+interface Props {
+  template: RiaFormTemplate;
+  onSave: (structure: RiaFormStructure) => Promise<void>;
+}
+
+function generateId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+}
+
+export function RiaTemplateEditor({ template, onSave }: Props) {
+  const [structure, setStructure] = useState<RiaFormStructure>(template.structure);
+  const [isSaving, setIsSaving] = useState(false);
+  const [expandedSteps, setExpandedSteps] = useState<Set<string>>(new Set());
+  const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set());
+  const [deleteTarget, setDeleteTarget] = useState<{
+    type: 'section' | 'question';
+    stepId: string;
+    sectionId: string;
+    questionId?: string;
+  } | null>(null);
+
+  const toggleStep = (stepId: string) => {
+    setExpandedSteps((prev) => {
+      const next = new Set(prev);
+      if (next.has(stepId)) next.delete(stepId);
+      else next.add(stepId);
+      return next;
+    });
+  };
+
+  const toggleSection = (sectionId: string) => {
+    setExpandedSections((prev) => {
+      const next = new Set(prev);
+      if (next.has(sectionId)) next.delete(sectionId);
+      else next.add(sectionId);
+      return next;
+    });
+  };
+
+  const updateStepTitle = useCallback((stepId: string, title: string) => {
+    setStructure((prev) => ({
+      ...prev,
+      steps: prev.steps.map((s) => (s.id === stepId ? { ...s, title } : s)),
+    }));
+  }, []);
+
+  const updateSectionTitle = useCallback((stepId: string, sectionId: string, title: string) => {
+    setStructure((prev) => ({
+      ...prev,
+      steps: prev.steps.map((s) =>
+        s.id !== stepId
+          ? s
+          : {
+              ...s,
+              sections: s.sections?.map((sec) =>
+                sec.id === sectionId ? { ...sec, title } : sec
+              ),
+            }
+      ),
+    }));
+  }, []);
+
+  const updateQuestion = useCallback(
+    (stepId: string, sectionId: string, questionId: string, patch: Partial<RiaFormQuestion>) => {
+      setStructure((prev) => ({
+        ...prev,
+        steps: prev.steps.map((s) =>
+          s.id !== stepId
+            ? s
+            : {
+                ...s,
+                sections: s.sections?.map((sec) =>
+                  sec.id !== sectionId
+                    ? sec
+                    : {
+                        ...sec,
+                        questions: sec.questions.map((q) =>
+                          q.id === questionId ? { ...q, ...patch } : q
+                        ),
+                      }
+                ),
+              }
+        ),
+      }));
+    },
+    []
+  );
+
+  const addSection = useCallback((stepId: string) => {
+    const newSection: RiaFormSection = {
+      id: generateId('section'),
+      title: 'Nueva sección',
+      questions: [],
+    };
+    setStructure((prev) => ({
+      ...prev,
+      steps: prev.steps.map((s) =>
+        s.id !== stepId
+          ? s
+          : { ...s, sections: [...(s.sections ?? []), newSection] }
+      ),
+    }));
+    setExpandedSections((prev) => new Set([...prev, newSection.id]));
+  }, []);
+
+  const addQuestion = useCallback((stepId: string, sectionId: string) => {
+    const newQuestion: RiaFormQuestion = {
+      id: generateId('q'),
+      key: `custom_${Date.now()}`,
+      label: 'Nueva pregunta',
+      tooltip: '',
+      affects_classification: false,
+      parent_question_id: null,
+      parent_answer_trigger: null,
+    };
+    setStructure((prev) => ({
+      ...prev,
+      steps: prev.steps.map((s) =>
+        s.id !== stepId
+          ? s
+          : {
+              ...s,
+              sections: s.sections?.map((sec) =>
+                sec.id !== sectionId
+                  ? sec
+                  : { ...sec, questions: [...sec.questions, newQuestion] }
+              ),
+            }
+      ),
+    }));
+  }, []);
+
+  const deleteSection = useCallback((stepId: string, sectionId: string) => {
+    setStructure((prev) => ({
+      ...prev,
+      steps: prev.steps.map((s) =>
+        s.id !== stepId
+          ? s
+          : { ...s, sections: s.sections?.filter((sec) => sec.id !== sectionId) }
+      ),
+    }));
+  }, []);
+
+  const deleteQuestion = useCallback((stepId: string, sectionId: string, questionId: string) => {
+    setStructure((prev) => ({
+      ...prev,
+      steps: prev.steps.map((s) =>
+        s.id !== stepId
+          ? s
+          : {
+              ...s,
+              sections: s.sections?.map((sec) =>
+                sec.id !== sectionId
+                  ? sec
+                  : { ...sec, questions: sec.questions.filter((q) => q.id !== questionId) }
+              ),
+            }
+      ),
+    }));
+  }, []);
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      await onSave(structure);
+      toast.success('Plantilla guardada', { description: 'Los cambios se han guardado correctamente.' });
+    } catch {
+      toast.error('Error al guardar', { description: 'No se pudieron guardar los cambios.' });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const editableSteps = structure.steps.filter((s) => s.type === 'questions');
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-gray-500">
+          Edita las secciones y preguntas de esta plantilla.
+        </p>
+        <Button onClick={handleSave} disabled={isSaving} size="sm">
+          {isSaving ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <Save className="w-4 h-4 mr-2" />}
+          Guardar cambios
+        </Button>
+      </div>
+
+      <div className="space-y-3">
+        {editableSteps.map((step) => {
+          const isExpanded = expandedSteps.has(step.id);
+          return (
+            <Card key={step.id}>
+              <CardHeader
+                className="cursor-pointer hover:bg-gray-50 rounded-t-lg py-3"
+                onClick={() => toggleStep(step.id)}
+              >
+                <div className="flex items-center gap-3">
+                  {isExpanded ? (
+                    <ChevronDown className="w-4 h-4 text-gray-400 shrink-0" />
+                  ) : (
+                    <ChevronRight className="w-4 h-4 text-gray-400 shrink-0" />
+                  )}
+                  <CardTitle className="text-base">{step.title}</CardTitle>
+                  <Badge variant="outline" className="ml-auto text-xs">
+                    {step.sections?.length ?? 0} secciones
+                  </Badge>
+                </div>
+              </CardHeader>
+
+              {isExpanded && (
+                <CardContent className="pt-0 space-y-3">
+                  <div className="space-y-1">
+                    <Label className="text-xs text-gray-500">Título del paso</Label>
+                    <Input
+                      value={step.title}
+                      onChange={(e) => updateStepTitle(step.id, e.target.value)}
+                      className="h-8 text-sm"
+                      onClick={(e) => e.stopPropagation()}
+                    />
+                  </div>
+
+                  {step.sections?.map((section) => (
+                    <SectionEditor
+                      key={section.id}
+                      step={step}
+                      section={section}
+                      expanded={expandedSections.has(section.id)}
+                      onToggle={() => toggleSection(section.id)}
+                      onUpdateTitle={(title) => updateSectionTitle(step.id, section.id, title)}
+                      onUpdateQuestion={(qId, patch) => updateQuestion(step.id, section.id, qId, patch)}
+                      onAddQuestion={() => addQuestion(step.id, section.id)}
+                      onDeleteSection={() =>
+                        setDeleteTarget({ type: 'section', stepId: step.id, sectionId: section.id })
+                      }
+                      onDeleteQuestion={(qId) =>
+                        setDeleteTarget({
+                          type: 'question',
+                          stepId: step.id,
+                          sectionId: section.id,
+                          questionId: qId,
+                        })
+                      }
+                    />
+                  ))}
+
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="w-full border-dashed"
+                    onClick={() => addSection(step.id)}
+                  >
+                    <Plus className="w-4 h-4 mr-1" />
+                    Añadir sección
+                  </Button>
+                </CardContent>
+              )}
+            </Card>
+          );
+        })}
+      </div>
+
+      <AlertDialog open={!!deleteTarget} onOpenChange={(open) => !open && setDeleteTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {deleteTarget?.type === 'section' ? '¿Eliminar sección?' : '¿Eliminar pregunta?'}
+            </AlertDialogTitle>
+            <AlertDialogDescription>Esta acción no se puede deshacer.</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-red-600 hover:bg-red-700"
+              onClick={() => {
+                if (!deleteTarget) return;
+                if (deleteTarget.type === 'section') {
+                  deleteSection(deleteTarget.stepId, deleteTarget.sectionId);
+                } else if (deleteTarget.questionId) {
+                  deleteQuestion(deleteTarget.stepId, deleteTarget.sectionId, deleteTarget.questionId);
+                }
+                setDeleteTarget(null);
+              }}
+            >
+              Eliminar
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+interface SectionEditorProps {
+  step: RiaFormStep;
+  section: RiaFormSection;
+  expanded: boolean;
+  onToggle: () => void;
+  onUpdateTitle: (title: string) => void;
+  onUpdateQuestion: (qId: string, patch: Partial<RiaFormQuestion>) => void;
+  onAddQuestion: () => void;
+  onDeleteSection: () => void;
+  onDeleteQuestion: (qId: string) => void;
+}
+
+function SectionEditor({
+  section,
+  expanded,
+  onToggle,
+  onUpdateTitle,
+  onUpdateQuestion,
+  onAddQuestion,
+  onDeleteSection,
+  onDeleteQuestion,
+}: SectionEditorProps) {
+  return (
+    <div className="border rounded-md">
+      <div
+        className="flex items-center gap-2 px-3 py-2 cursor-pointer hover:bg-gray-50 rounded-t-md"
+        onClick={onToggle}
+      >
+        <GripVertical className="w-4 h-4 text-gray-300 shrink-0" />
+        {expanded ? (
+          <ChevronDown className="w-3 h-3 text-gray-400 shrink-0" />
+        ) : (
+          <ChevronRight className="w-3 h-3 text-gray-400 shrink-0" />
+        )}
+        <span className="text-sm font-medium flex-1 truncate">{section.title}</span>
+        <Badge variant="secondary" className="text-xs shrink-0">
+          {section.questions.length} preguntas
+        </Badge>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 w-6 p-0 text-red-400 hover:text-red-600 hover:bg-red-50 shrink-0"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDeleteSection();
+          }}
+        >
+          <Trash2 className="w-3 h-3" />
+        </Button>
+      </div>
+
+      {expanded && (
+        <div className="px-3 pb-3 space-y-3 border-t pt-3">
+          <div className="space-y-1">
+            <Label className="text-xs text-gray-500">Nombre de la sección</Label>
+            <Input
+              value={section.title}
+              onChange={(e) => onUpdateTitle(e.target.value)}
+              className="h-8 text-sm"
+            />
+          </div>
+
+          {section.questions.map((question) => (
+            <QuestionEditor
+              key={question.id}
+              question={question}
+              onUpdate={(patch) => onUpdateQuestion(question.id, patch)}
+              onDelete={() => onDeleteQuestion(question.id)}
+            />
+          ))}
+
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full text-xs border border-dashed h-7"
+            onClick={onAddQuestion}
+          >
+            <Plus className="w-3 h-3 mr-1" />
+            Añadir pregunta
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface QuestionEditorProps {
+  question: RiaFormQuestion;
+  onUpdate: (patch: Partial<RiaFormQuestion>) => void;
+  onDelete: () => void;
+}
+
+function QuestionEditor({ question, onUpdate, onDelete }: QuestionEditorProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="border rounded bg-gray-50">
+      <div
+        className="flex items-center gap-2 px-3 py-2 cursor-pointer hover:bg-gray-100"
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <GripVertical className="w-3 h-3 text-gray-300 shrink-0" />
+        <span className="text-xs flex-1 truncate">{question.label}</span>
+        {question.affects_classification && (
+          <Badge variant="outline" className="text-xs border-blue-200 text-blue-600 shrink-0">
+            clasificación
+          </Badge>
+        )}
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-5 w-5 p-0 text-red-400 hover:text-red-600 hover:bg-red-50 shrink-0"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete();
+          }}
+        >
+          <Trash2 className="w-3 h-3" />
+        </Button>
+      </div>
+
+      {expanded && (
+        <div className="px-3 pb-3 border-t space-y-3 pt-2">
+          <div className="space-y-1">
+            <Label className="text-xs text-gray-500">Texto de la pregunta</Label>
+            <Textarea
+              value={question.label}
+              onChange={(e) => onUpdate({ label: e.target.value })}
+              rows={2}
+              className="text-xs"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <Label className="text-xs text-gray-500">Tooltip / ayuda</Label>
+            <Textarea
+              value={question.tooltip ?? ''}
+              onChange={(e) => onUpdate({ tooltip: e.target.value })}
+              rows={2}
+              className="text-xs"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <Label className="text-xs text-gray-500">Clave de campo</Label>
+            <Input
+              value={question.key}
+              onChange={(e) => onUpdate({ key: e.target.value })}
+              className="h-7 text-xs font-mono"
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Switch
+              id={`affects-${question.id}`}
+              checked={question.affects_classification}
+              onCheckedChange={(checked) => onUpdate({ affects_classification: checked })}
+            />
+            <Label htmlFor={`affects-${question.id}`} className="text-xs">
+              Afecta a la clasificación de riesgo
+            </Label>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/dashboard/admin/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/admin/page.tsx
@@ -5,9 +5,10 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
-import { FileWarning, FormInput, Settings2, ArrowLeft } from 'lucide-react';
+import { FileWarning, FormInput, Settings2, ArrowLeft, ClipboardList } from 'lucide-react';
 import { RiskTemplatesPanel } from './components/risk-templates-panel';
 import { CustomFieldsPanel } from './components/custom-fields-panel';
+import { RiaFormPanel } from './components/ria-form-panel';
 import { usePermissions } from '@/hooks/use-permissions';
 import { toast } from 'sonner'
 
@@ -38,7 +39,7 @@ export default function AdminPage() {
       </div>
       
       <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
-        <TabsList className="grid w-full max-w-md grid-cols-2">
+        <TabsList className="grid w-full max-w-2xl grid-cols-3">
           <TabsTrigger value="risk-templates" className="flex items-center gap-2">
             <FileWarning className="w-4 h-4" />
             Plantillas de Riesgos
@@ -47,14 +48,22 @@ export default function AdminPage() {
             <FormInput className="w-4 h-4" />
             Campos Adicionales
           </TabsTrigger>
+          <TabsTrigger value="ria-form" className="flex items-center gap-2">
+            <ClipboardList className="w-4 h-4" />
+            Formulario RIA
+          </TabsTrigger>
         </TabsList>
-        
+
         <TabsContent value="risk-templates" className="mt-6">
           <RiskTemplatesPanel />
         </TabsContent>
-        
+
         <TabsContent value="custom-fields" className="mt-6">
           <CustomFieldsPanel />
+        </TabsContent>
+
+        <TabsContent value="ria-form" className="mt-6">
+          <RiaFormPanel />
         </TabsContent>
       </Tabs>
     </div>

--- a/apps/web/app/(dashboard)/dashboard/inventory/[id]/classify/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/inventory/[id]/classify/page.tsx
@@ -1,187 +1,72 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useRouter, useParams } from 'next/navigation';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { useForm } from 'react-hook-form';
-import { z } from 'zod';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-} from '@/components/ui/form';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import {
   AlertCircle,
   Shield,
   AlertTriangle,
   CheckCircle2,
-  HelpCircle,
   Brain,
-  Cpu,
   Sparkles,
-  Bot,
   MessageSquare,
   X,
+  FileText,
 } from 'lucide-react';
 import { Breadcrumb } from '@/components/ui/breadcrumb';
 import { supabase } from '@/lib/supabase';
 import { AIClassificationAssistant } from '@/components/ai-classification-assistant';
+import { RiaFormRenderer, getRiaStepCount, getRiaStepTitle } from '@/components/ria-form-renderer';
+import { evaluateRiaClassification, evaluateTransparencyRequired } from '@/lib/utils/ria-classification';
+import type { RiaFormTemplate, RiaFormAnswers } from '@/types/ria-form-template';
 
-// ── Schema ───────────────────────────────────────────────────────────────────
-
-const yesNo = z.enum(['yes', 'no']);
-
-const classificationSchema = z.object({
-  systemType: z.enum(['gpai_base', 'gpai_systemic', 'specific', 'multipurpose']),
-  p2_1: yesNo, p2_2: yesNo, p2_3: yesNo, p2_3a: yesNo,
-  p2_4: yesNo, p2_5: yesNo, p2_6: yesNo,
-  p3_1: yesNo, p3_2: yesNo, p3_3: yesNo, p3_3a: yesNo,
-  p3_4: yesNo, p3_5: yesNo, p3_6: yesNo,
-  p3_7: yesNo, p3_8: yesNo, p3_9: yesNo,
-  p4_1: yesNo, p4_2: yesNo, p4_3: yesNo, p4_4: yesNo,
-});
-
-type FormValues = z.infer<typeof classificationSchema>;
-
-// ── Constants ────────────────────────────────────────────────────────────────
+// ── Risk level display config ─────────────────────────────────────────────────
 
 const riskLevels = {
-  prohibited: { label: 'Prohibido', color: 'bg-red-100 text-red-800 border-red-200', icon: AlertCircle, description: 'Este sistema de IA está prohibido por el Artículo 5 del AI Act y no puede desplegarse en la UE.' },
-  high_risk: { label: 'Alto Riesgo', color: 'bg-orange-100 text-orange-800 border-orange-200', icon: AlertTriangle, description: 'Sistema de alto riesgo sujeto a obligaciones estrictas de cumplimiento (Arts. 9-15).' },
-  gpai_regime: { label: 'Régimen GPAI', color: 'bg-purple-100 text-purple-800 border-purple-200', icon: Brain, description: 'Modelo de IA de propósito general sujeto a las obligaciones del Artículo 53 del AI Act.' },
-  limited_risk: { label: 'Riesgo Limitado', color: 'bg-yellow-100 text-yellow-800 border-yellow-200', icon: Shield, description: 'Sujeto a obligaciones de transparencia (Art. 50).' },
-  minimal_risk: { label: 'Riesgo Mínimo', color: 'bg-green-100 text-green-800 border-green-200', icon: CheckCircle2, description: 'Libre uso con recomendación de códigos de conducta voluntarios.' },
-};
-
-const systemTypes = [
-  {
-    value: 'gpai_base' as const,
-    label: 'Modelo GPAI',
-    description: 'Entreno y distribuyo un modelo base sin interfaz ni caso de uso propio',
-    examples: 'LLM propio, modelo de embeddings propietario',
-    badge: null as string | null,
+  prohibited: {
+    label: 'Prohibido',
+    color: 'bg-red-100 text-red-800 border-red-200',
+    icon: AlertCircle,
+    description: 'Este sistema de IA está prohibido por el Artículo 5 del AI Act y no puede desplegarse en la UE.',
+  },
+  high_risk: {
+    label: 'Alto Riesgo',
+    color: 'bg-orange-100 text-orange-800 border-orange-200',
+    icon: AlertTriangle,
+    description: 'Sistema de alto riesgo sujeto a obligaciones estrictas de cumplimiento (Arts. 9-15).',
+  },
+  gpai_regime: {
+    label: 'Régimen GPAI',
+    color: 'bg-purple-100 text-purple-800 border-purple-200',
     icon: Brain,
-    tooltip: 'Un modelo GPAI (General Purpose AI) es un modelo entrenado con grandes cantidades de datos que puede realizar múltiples tipos de tareas. Si eres tú quien lo entrena y lo distribuye —sin definir un caso de uso concreto— selecciona esta opción. Si lo que haces es usar un modelo de otro (OpenAI, Anthropic, etc.) para construir tu aplicación, no eres proveedor de un modelo GPAI.',
+    description: 'Modelo de IA de propósito general sujeto a las obligaciones del Artículo 53 del AI Act.',
   },
-  {
-    value: 'gpai_systemic' as const,
-    label: 'Modelo GPAI de alto impacto',
-    description: 'Mi modelo supera 10²⁵ FLOP de entrenamiento o ha sido designado por la Comisión Europea',
-    examples: 'Modelos frontier de grandes laboratorios de IA',
-    badge: null as string | null,
-    icon: Sparkles,
-    tooltip: 'El AI Act define un umbral cuantitativo de 10²⁵ FLOP de cómputo de entrenamiento para considerar un modelo GPAI de "riesgo sistémico". También puede ser designado por la Comisión Europea en base a otros criterios como el número de usuarios o capacidades en dominios críticos. Esta categoría aplica a muy pocos actores a nivel mundial.',
+  limited_risk: {
+    label: 'Riesgo Limitado',
+    color: 'bg-yellow-100 text-yellow-800 border-yellow-200',
+    icon: Shield,
+    description: 'Sujeto a obligaciones de transparencia (Art. 50).',
   },
-  {
-    value: 'specific' as const,
-    label: 'Sistema con finalidad definida',
-    description: 'Aplico IA a un caso de uso concreto, aunque use un modelo de terceros',
-    examples: 'Chatbot, detector de fraude, scoring de crédito, generador de contratos',
-    badge: '★ más habitual' as string | null,
-    icon: Cpu,
-    tooltip: 'Es la categoría más frecuente para PYMEs. Si tu sistema tiene un propósito claro y específico —aunque por debajo use GPT-4 u otro modelo— selecciona esta opción. La finalidad concreta es lo que determina el riesgo regulatorio, no el modelo subyacente.',
+  minimal_risk: {
+    label: 'Riesgo Mínimo',
+    color: 'bg-green-100 text-green-800 border-green-200',
+    icon: CheckCircle2,
+    description: 'Libre uso con recomendación de códigos de conducta voluntarios.',
   },
-  {
-    value: 'multipurpose' as const,
-    label: 'Sistema con múltiples usos',
-    description: 'Mi sistema puede aplicarse a distintos casos de uso sin uno único definido',
-    examples: 'Plataforma de automatización corporativa, asistente IA multiuso interno',
-    badge: null as string | null,
-    icon: Bot,
-    tooltip: 'Selecciona esta opción si tu sistema está diseñado para que distintos departamentos o clientes lo usen con finalidades diferentes, sin una única función predefinida. En este caso, el AI Act exige evaluar el riesgo por cada caso de uso concreto. CumplIA te mostrará una advertencia para que repitas la evaluación por cada uso previsto.',
-  },
-];
-
-const YES_NO_FIELDS: (keyof FormValues)[] = [
-  'p2_1', 'p2_2', 'p2_3', 'p2_3a', 'p2_4', 'p2_5', 'p2_6',
-  'p3_1', 'p3_2', 'p3_3', 'p3_3a', 'p3_4', 'p3_5', 'p3_6', 'p3_7', 'p3_8', 'p3_9',
-  'p4_1', 'p4_2', 'p4_3', 'p4_4',
-];
-
-// ── Helpers ──────────────────────────────────────────────────────────────────
-
-function InfoTooltip({ text }: { text: string }) {
-  const [show, setShow] = useState(false);
-  const [position, setPosition] = useState<'top' | 'bottom'>('top');
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (show && containerRef.current) {
-      const rect = containerRef.current.getBoundingClientRect();
-      if (rect.top < 150 && window.innerHeight - rect.bottom > 150) setPosition('bottom');
-      else setPosition('top');
-    }
-  }, [show]);
-
-  return (
-    <div ref={containerRef} className="relative inline-flex items-center ml-2" onMouseEnter={() => setShow(true)} onMouseLeave={() => setShow(false)}>
-      <HelpCircle className="w-4 h-4 text-gray-400 cursor-help hover:text-blue-500 transition-colors" />
-      {show && (
-        <div className={`absolute ${position === 'top' ? 'bottom-full mb-3' : 'top-full mt-3'} left-1/2 -translate-x-1/2 px-4 py-3 bg-gray-900 text-white text-sm rounded-xl shadow-2xl z-[9999] w-80 leading-relaxed pointer-events-none`}>
-          {text}
-          <div className={`absolute left-1/2 -translate-x-1/2 w-0 h-0 border-x-8 border-x-transparent ${position === 'top' ? 'top-full border-t-8 border-t-gray-900' : 'bottom-full border-b-8 border-b-gray-900'}`} />
-        </div>
-      )}
-    </div>
-  );
-}
-
-function SectionDivider({ title }: { title: string }) {
-  return (
-    <div className="flex items-center gap-3 py-1">
-      <div className="h-px flex-1 bg-gray-200" />
-      <span className="text-xs font-semibold text-gray-500 uppercase tracking-wider">{title}</span>
-      <div className="h-px flex-1 bg-gray-200" />
-    </div>
-  );
-}
-
-function YesNoSelector({ value, onChange, label, tooltip, isAiFilling, aiFilled }: {
-  value: string;
-  onChange: (val: 'yes' | 'no') => void;
-  label: string;
-  tooltip?: string;
-  isAiFilling?: boolean;
-  aiFilled?: boolean;
-}) {
-  return (
-    <div
-      className={`relative rounded-xl border-2 p-4 transition-all cursor-pointer
-        ${aiFilled ? 'border-blue-300 bg-blue-50/50' : 'border-gray-100 hover:border-blue-200 hover:bg-blue-50/30'}`}
-      onClick={() => onChange(value === 'yes' ? 'no' : 'yes')}
-    >
-      {/* AI wave animation overlay — overflow-hidden aquí para no clipar el tooltip */}
-      {isAiFilling && (
-        <div className="absolute inset-0 overflow-hidden rounded-xl pointer-events-none">
-          <div className="h-full bg-gradient-to-r from-blue-100/0 via-blue-200/60 to-blue-100/0 animate-[shimmer_1.5s_ease-in-out_infinite]" />
-        </div>
-      )}
-      <div className="flex items-center justify-between gap-4 relative z-10">
-        <div className="flex items-center gap-2 flex-1">
-          <span className="font-medium text-gray-900 text-sm">{label}</span>
-          {tooltip && <InfoTooltip text={tooltip} />}
-        </div>
-        <div className="flex gap-2 shrink-0" onClick={(e) => e.stopPropagation()}>
-          <button type="button" onClick={() => onChange('yes')} className={`px-5 py-2 rounded-lg font-semibold text-sm transition-all ${value === 'yes' ? 'bg-green-500 text-white shadow-md ring-2 ring-green-200' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}>Sí</button>
-          <button type="button" onClick={() => onChange('no')} className={`px-5 py-2 rounded-lg font-semibold text-sm transition-all ${value === 'no' ? 'bg-gray-500 text-white shadow-md ring-2 ring-gray-300' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}>No</button>
-        </div>
-      </div>
-      {aiFilled && (
-        <div className="flex items-center gap-1 mt-2 relative z-10">
-          <Sparkles className="w-3 h-3 text-blue-500" />
-          <span className="text-xs text-blue-600 font-medium">Completado por IA</span>
-        </div>
-      )}
-    </div>
-  );
-}
+};
 
 // ── Component ────────────────────────────────────────────────────────────────
 
@@ -189,73 +74,96 @@ export default function ClassifyUseCasePage() {
   const router = useRouter();
   const params = useParams();
   const useCaseId = params.id as string;
-  const [useCase, setUseCase] = useState<any>(null);
+
+  const [useCase, setUseCase] = useState<Record<string, unknown> | null>(null);
   const [loading, setLoading] = useState(true);
   const [calculating, setCalculating] = useState(false);
   const [result, setResult] = useState<{ level: string; transparencyRequired: boolean } | null>(null);
   const [currentStep, setCurrentStep] = useState(1);
   const [finalStepReady, setFinalStepReady] = useState(false);
 
-  // AI auto-fill state
+  const [template, setTemplate] = useState<RiaFormTemplate | null>(null);
+  const [allTemplates, setAllTemplates] = useState<RiaFormTemplate[]>([]);
+  const [answers, setAnswers] = useState<RiaFormAnswers>({});
+
   const [isAiFilling, setIsAiFilling] = useState(false);
   const [aiFillProgress, setAiFillProgress] = useState(0);
   const [aiFilledFields, setAiFilledFields] = useState<Set<string>>(new Set());
   const [showChat, setShowChat] = useState(false);
   const [unclearQuestions, setUnclearQuestions] = useState<string[]>([]);
 
-  const form = useForm<FormValues>({
-    resolver: zodResolver(classificationSchema),
-    defaultValues: {
-      systemType: 'specific',
-      p2_1: 'no', p2_2: 'no', p2_3: 'no', p2_3a: 'no', p2_4: 'no', p2_5: 'no', p2_6: 'no',
-      p3_1: 'no', p3_2: 'no', p3_3: 'no', p3_3a: 'no', p3_4: 'no', p3_5: 'no', p3_6: 'no',
-      p3_7: 'no', p3_8: 'no', p3_9: 'no',
-      p4_1: 'no', p4_2: 'no', p4_3: 'no', p4_4: 'no',
-    },
-  });
-
-  const selectedSystemType = form.watch('systemType');
-  const p2_3Value = form.watch('p2_3');
-  const p3_3Value = form.watch('p3_3');
-
-  const isGPAI = selectedSystemType === 'gpai_base' || selectedSystemType === 'gpai_systemic';
-
-  useEffect(() => { loadUseCase(); }, [useCaseId]);
-
-  const totalSteps = isGPAI ? 3 : 4;
+  const totalSteps = template ? getRiaStepCount(template, answers) : 0;
 
   useEffect(() => {
-    if (currentStep === totalSteps) {
+    if (currentStep === totalSteps && totalSteps > 0) {
       setFinalStepReady(false);
       const timer = setTimeout(() => setFinalStepReady(true), 600);
       return () => clearTimeout(timer);
     }
   }, [currentStep, totalSteps]);
 
-  async function loadUseCase() {
+  useEffect(() => {
+    loadData();
+  }, [useCaseId]);
+
+  async function loadData() {
+    setLoading(true);
     try {
-      const { data, error } = await supabase.from('use_cases').select('*').eq('id', useCaseId).single();
-      if (error) throw error;
-      setUseCase(data);
-      if (data?.classification_data && !data.classification_data.ai_assisted) {
-        const prevData = data.classification_data;
-        const knownTypes = ['gpai_base', 'gpai_systemic', 'specific', 'multipurpose'];
-        if (knownTypes.includes(prevData.systemType) || prevData.p2_1 !== undefined) {
-          const convertedData: Partial<FormValues> = { systemType: prevData.systemType || 'specific' };
-          YES_NO_FIELDS.forEach(key => {
-            if (prevData[key] === 'yes' || prevData[key] === 'no') {
-              (convertedData as any)[key] = prevData[key];
-            }
-          });
-          form.reset(convertedData as FormValues);
-        }
+      const [ucResult, tplResult, allTplResult] = await Promise.all([
+        supabase.from('use_cases').select('*').eq('id', useCaseId).single(),
+        fetch(`/api/v1/ai-systems/${useCaseId}/ria-template`),
+        fetch('/api/v1/ria-templates'),
+      ]);
+
+      if (ucResult.error) throw ucResult.error;
+      setUseCase(ucResult.data);
+
+      const tplJson = await tplResult.json();
+      if (tplJson.success && tplJson.data) {
+        setTemplate(tplJson.data);
       }
-    } catch (error) {
-      console.error('Error loading use case:', error);
+
+      const allTplJson = await allTplResult.json();
+      if (allTplJson.success) {
+        setAllTemplates(allTplJson.data);
+      }
+
+      if (ucResult.data?.classification_data && !ucResult.data.classification_data.ai_assisted) {
+        const prevData = ucResult.data.classification_data as RiaFormAnswers;
+        setAnswers(prevData);
+      } else {
+        setAnswers({});
+      }
+    } catch {
       toast.error('Error', { description: 'No se pudo cargar el sistema de IA' });
       router.push('/dashboard/inventory');
-    } finally { setLoading(false); }
+    } finally {
+      setLoading(false);
+    }
   }
+
+  const handleAnswerChange = (key: string, value: string) => {
+    setAnswers((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleTemplateChange = async (templateId: string) => {
+    const found = allTemplates.find((t) => t.id === templateId);
+    if (!found) return;
+    setTemplate(found);
+    setCurrentStep(1);
+    setAnswers({});
+    setResult(null);
+
+    try {
+      await fetch(`/api/v1/ai-systems/${useCaseId}/ria-template`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ template_id: templateId }),
+      });
+    } catch {
+      // Non-critical — template selection is persisted best-effort
+    }
+  };
 
   // ── AI Auto-fill ──────────────────────────────────────────────────────────
 
@@ -280,94 +188,67 @@ export default function ClassifyUseCasePage() {
 
       if (!res.ok) throw new Error('Error al analizar el sistema');
       const data = await res.json();
-
       if (!data.answers) throw new Error('Respuesta inválida');
 
-      // Animate filling each field with a stagger
-      const answers = data.answers as Record<string, string>;
-      const fieldsToFill = Object.keys(answers).filter(
-        k => answers[k] === 'yes' || answers[k] === 'no' || k === 'systemType'
+      const incoming = data.answers as Record<string, string>;
+      const keys = Object.keys(incoming).filter(
+        (k) => incoming[k] === 'yes' || incoming[k] === 'no' || k === 'systemType'
       );
 
-      // Fill systemType immediately
-      if (answers.systemType) {
-        form.setValue('systemType', answers.systemType as any);
+      if (incoming.systemType) {
+        setAnswers((prev) => ({ ...prev, systemType: incoming.systemType }));
       }
 
-      // Animate yes/no fields
-      for (let i = 0; i < fieldsToFill.length; i++) {
-        const key = fieldsToFill[i];
+      for (let i = 0; i < keys.length; i++) {
+        const key = keys[i];
         if (key === 'systemType') continue;
-        const value = answers[key];
-        if (value === 'yes' || value === 'no') {
-          await new Promise(r => setTimeout(r, 80)); // stagger delay
-          form.setValue(key as any, value as any);
-          setAiFilledFields(prev => new Set([...prev, key]));
-          setAiFillProgress(Math.round(((i + 1) / fieldsToFill.length) * 100));
+        const val = incoming[key];
+        if (val === 'yes' || val === 'no') {
+          await new Promise((r) => setTimeout(r, 80));
+          setAnswers((prev) => ({ ...prev, [key]: val }));
+          setAiFilledFields((prev) => new Set([...prev, key]));
+          setAiFillProgress(Math.round(((i + 1) / keys.length) * 100));
         }
       }
 
-      // Handle unclear fields
-      const unclear = data.unclear_fields || [];
-      const questions = data.unclear_questions || [];
+      const unclear = data.unclear_fields ?? [];
+      const questions = data.unclear_questions ?? [];
       if (unclear.length > 0 && questions.length > 0) {
         setUnclearQuestions(questions);
         setShowChat(true);
-        toast.success('Necesito más información', { description: `La IA necesita aclarar ${unclear.length} preguntas. Se ha abierto el chat.` });
+        toast.success('Necesito más información', {
+          description: `La IA necesita aclarar ${unclear.length} preguntas. Se ha abierto el chat.`,
+        });
       } else {
-        toast.success('Cuestionario completado por IA', { description: `Confianza: ${data.confidence === 'high' ? 'Alta' : data.confidence === 'medium' ? 'Media' : 'Baja'}. Revisa las respuestas antes de finalizar.` });
+        toast.success('Cuestionario completado por IA', {
+          description: `Confianza: ${data.confidence === 'high' ? 'Alta' : data.confidence === 'medium' ? 'Media' : 'Baja'}. Revisa las respuestas antes de finalizar.`,
+        });
       }
-    } catch (err: any) {
-      toast.error('Error', { description: err.message ?? 'No se pudo completar con IA' });
+    } catch (err) {
+      toast.error('Error', {
+        description: err instanceof Error ? err.message : 'No se pudo completar con IA',
+      });
     } finally {
       setIsAiFilling(false);
       setAiFillProgress(100);
     }
   }
 
-  // ── Classification logic ──────────────────────────────────────────────────
+  // ── Submit ────────────────────────────────────────────────────────────────
 
-  function calculateRiskLevel(values: FormValues): { level: string; transparencyRequired: boolean } {
-    const transparencyRequired =
-      values.p4_1 === 'yes' || values.p4_2 === 'yes' || values.p4_3 === 'yes' || values.p4_4 === 'yes';
-
-    const isProhibited =
-      values.p2_1 === 'yes' || values.p2_2 === 'yes' ||
-      (values.p2_3 === 'yes' && values.p2_3a !== 'yes') ||
-      values.p2_4 === 'yes' || values.p2_5 === 'yes' || values.p2_6 === 'yes';
-    if (isProhibited) return { level: 'prohibited', transparencyRequired };
-
-    if (values.systemType === 'gpai_systemic') return { level: 'high_risk', transparencyRequired };
-
-    const isHighRisk =
-      (values.p2_3 === 'yes' && values.p2_3a === 'yes') ||
-      values.p3_1 === 'yes' || values.p3_2 === 'yes' ||
-      (values.p3_3 === 'yes' && values.p3_3a === 'yes') ||
-      values.p3_4 === 'yes' || values.p3_5 === 'yes' || values.p3_6 === 'yes' ||
-      values.p3_7 === 'yes' || values.p3_8 === 'yes' || values.p3_9 === 'yes';
-    if (isHighRisk) return { level: 'high_risk', transparencyRequired };
-
-    if (values.systemType === 'gpai_base') return { level: 'gpai_regime', transparencyRequired };
-    if (values.systemType === 'multipurpose') return { level: 'limited_risk', transparencyRequired };
-    if (transparencyRequired) return { level: 'limited_risk', transparencyRequired };
-    return { level: 'minimal_risk', transparencyRequired };
-  }
-
-  async function onSubmit(values: FormValues) {
+  async function handleSubmit() {
+    if (!template) return;
     setCalculating(true);
     try {
-      const classificationResult = calculateRiskLevel(values);
+      const level = evaluateRiaClassification(template.classification_rules, answers);
+      const transparencyRequired = evaluateTransparencyRequired(template.classification_rules, answers);
+      const classificationResult = { level, transparencyRequired };
+
       const { data: { session } } = await supabase.auth.getSession();
 
-      const classificationData = {
-        ...values,
-        p2_3a: values.p2_3 === 'yes' ? values.p2_3a : null,
-        p3_3a: values.p3_3 === 'yes' ? values.p3_3a : null,
-      };
-
       await supabase.from('use_cases').update({
-        ai_act_level: classificationResult.level,
-        classification_data: classificationData,
+        ai_act_level: level,
+        classification_data: answers,
         status: 'classified',
         updated_at: new Date().toISOString(),
       }).eq('id', useCaseId);
@@ -382,8 +263,8 @@ export default function ClassifyUseCasePage() {
         await supabase.from('use_case_versions').insert({
           use_case_id: useCaseId,
           version_number: 1,
-          classification_data: classificationData,
-          ai_act_level: classificationResult.level,
+          classification_data: answers,
+          ai_act_level: level,
           created_by: session?.user?.id,
           notes: 'Versión inicial - Primera clasificación',
         });
@@ -391,51 +272,54 @@ export default function ClassifyUseCasePage() {
 
       setResult(classificationResult);
       toast.success('Clasificación Completada', {
-        description: `El sistema ha sido clasificado como: ${riskLevels[classificationResult.level as keyof typeof riskLevels].label}`,
+        description: `El sistema ha sido clasificado como: ${riskLevels[level as keyof typeof riskLevels]?.label ?? level}`,
       });
-    } catch (error: any) {
-      toast.error('Error', { description: error.message || 'No se pudo guardar' });
-    } finally { setCalculating(false); }
+    } catch (error) {
+      toast.error('Error', {
+        description: error instanceof Error ? error.message : 'No se pudo guardar',
+      });
+    } finally {
+      setCalculating(false);
+    }
   }
 
-  // ── Step navigation ───────────────────────────────────────────────────────
+  // ── Loading ───────────────────────────────────────────────────────────────
 
-  const progressValue = (currentStep / totalSteps) * 100;
+  if (loading) {
+    return (
+      <div className="p-4 sm:p-8 bg-gray-50 min-h-screen flex items-center justify-center">
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 bg-muted rounded w-48" />
+          <div className="h-64 bg-muted rounded w-96" />
+        </div>
+      </div>
+    );
+  }
 
-  const handleNextStep = () => {
-    setCurrentStep(prev => Math.min(prev + 1, totalSteps));
-  };
-
-  // ── Render ────────────────────────────────────────────────────────────────
-
-  if (loading) return (
-    <div className="p-4 sm:p-8 bg-gray-50 min-h-screen flex items-center justify-center">
-      <div className="animate-pulse space-y-4"><div className="h-8 bg-muted rounded w-48" /><div className="h-64 bg-muted rounded w-96" /></div>
-    </div>
-  );
+  // ── Result screen ─────────────────────────────────────────────────────────
 
   if (result) {
     const riskInfo = riskLevels[result.level as keyof typeof riskLevels];
-    const RiskIcon = riskInfo.icon;
+    const RiskIcon = riskInfo?.icon ?? CheckCircle2;
     return (
       <div className="p-4 sm:p-8 bg-gray-50 min-h-screen">
         <div className="max-w-2xl mx-auto">
           <Card className="border-2">
             <CardContent className="p-8 text-center">
-              <div className={`w-20 h-20 ${riskInfo.color.split(' ')[0]} rounded-full flex items-center justify-center mx-auto mb-6`}>
-                <RiskIcon className={`w-10 h-10 ${riskInfo.color.split(' ')[1]}`} />
+              <div className={`w-20 h-20 ${riskInfo?.color.split(' ')[0]} rounded-full flex items-center justify-center mx-auto mb-6`}>
+                <RiskIcon className={`w-10 h-10 ${riskInfo?.color.split(' ')[1]}`} />
               </div>
               <h1 className="text-2xl font-bold text-gray-900 mb-2">Clasificación Completada</h1>
               <div className="flex flex-wrap gap-2 justify-center mb-4">
-                <Badge className={`text-lg px-4 py-1 ${riskInfo.color}`}>{riskInfo.label}</Badge>
+                <Badge className={`text-lg px-4 py-1 ${riskInfo?.color}`}>{riskInfo?.label}</Badge>
                 {result.transparencyRequired && (
                   <Badge className="text-sm px-3 py-1 bg-yellow-100 text-yellow-800 border-yellow-200">
                     Transparencia obligatoria (Art. 50)
                   </Badge>
                 )}
               </div>
-              <p className="text-gray-600 mb-6">{riskInfo.description}</p>
-              {result.level === 'limited_risk' && form.getValues('systemType') === 'multipurpose' && (
+              <p className="text-gray-600 mb-6">{riskInfo?.description}</p>
+              {result.level === 'limited_risk' && answers['systemType'] === 'multipurpose' && (
                 <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 mb-6 text-left">
                   <p className="text-sm text-yellow-800">
                     <AlertTriangle className="w-4 h-4 inline mr-1" />
@@ -444,12 +328,16 @@ export default function ClassifyUseCasePage() {
                 </div>
               )}
               <div className="bg-gray-50 rounded-lg p-4 mb-6 text-left">
-                <h3 className="font-semibold text-gray-900 mb-2">{useCase?.name}</h3>
-                <p className="text-sm text-gray-600">{useCase?.description}</p>
+                <h3 className="font-semibold text-gray-900 mb-2">{String(useCase?.name ?? '')}</h3>
+                <p className="text-sm text-gray-600">{String(useCase?.description ?? '')}</p>
               </div>
               <div className="flex flex-col sm:flex-row gap-3 justify-center">
-                <Link href="/dashboard/inventory"><Button size="lg">Ver en el Inventario</Button></Link>
-                <Link href={`/dashboard/inventory/${useCaseId}`}><Button variant="outline" size="lg">Ver Detalles</Button></Link>
+                <Link href="/dashboard/inventory">
+                  <Button size="lg">Ver en el Inventario</Button>
+                </Link>
+                <Link href={`/dashboard/inventory/${useCaseId}`}>
+                  <Button variant="outline" size="lg">Ver Detalles</Button>
+                </Link>
               </div>
             </CardContent>
           </Card>
@@ -458,26 +346,31 @@ export default function ClassifyUseCasePage() {
     );
   }
 
+  const progressValue = totalSteps > 0 ? (currentStep / totalSteps) * 100 : 0;
+  const stepTitle = template ? getRiaStepTitle(template, answers, currentStep) : '';
+
+  // ── Form ──────────────────────────────────────────────────────────────────
+
   return (
     <div className="p-4 sm:p-8 bg-gray-50 min-h-screen">
       <div className="max-w-3xl mx-auto">
         <Breadcrumb
           items={[
             { label: 'Inventario', href: '/dashboard/inventory' },
-            { label: useCase?.name || '...', href: `/dashboard/inventory/${useCaseId}` },
+            { label: String(useCase?.name ?? '...'), href: `/dashboard/inventory/${useCaseId}` },
             { label: 'Clasificar' },
           ]}
         />
-        {/* Header */}
-        <div className="flex items-center gap-3 mb-6">
+
+        <div className="flex items-start gap-3 mb-6">
           <div className="flex-1">
             <h1 className="text-2xl font-bold text-gray-900">Clasificar Sistema de IA</h1>
             <p className="text-gray-600">Cuestionario de clasificación AI Act</p>
           </div>
           <Button
             onClick={handleAiFill}
-            disabled={isAiFilling}
-            className="bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white shadow-lg"
+            disabled={isAiFilling || !template}
+            className="bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white shadow-lg shrink-0"
           >
             {isAiFilling ? (
               <>
@@ -493,7 +386,26 @@ export default function ClassifyUseCasePage() {
           </Button>
         </div>
 
-        {/* Progress */}
+        {allTemplates.length > 1 && (
+          <div className="mb-4 flex items-center gap-3">
+            <FileText className="w-4 h-4 text-gray-400 shrink-0" />
+            <Select value={template?.id ?? ''} onValueChange={handleTemplateChange}>
+              <SelectTrigger className="w-72">
+                <SelectValue placeholder="Selecciona plantilla..." />
+              </SelectTrigger>
+              <SelectContent>
+                {allTemplates.map((t) => (
+                  <SelectItem key={t.id} value={t.id}>
+                    {t.name}
+                    {t.is_system ? ' (sistema)' : ''}
+                    {t.is_default && !t.is_system ? ' (predeterminada)' : ''}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+
         <div className="mb-6">
           <div className="flex justify-between text-sm mb-2">
             <span className="text-gray-600">Progreso</span>
@@ -502,318 +414,63 @@ export default function ClassifyUseCasePage() {
           <Progress value={progressValue} className="h-2" />
         </div>
 
-        {/* Questionnaire */}
         <Card>
           <CardHeader>
-            <CardTitle className="flex items-center gap-2"><Shield className="w-5 h-5" />Cuestionario de Clasificación AI Act</CardTitle>
+            <CardTitle className="flex items-center gap-2">
+              <Shield className="w-5 h-5" />
+              {stepTitle || 'Cuestionario de Clasificación AI Act'}
+            </CardTitle>
             <CardDescription>
-              Responde Sí o No a cada pregunta. Puedes usar <span className="font-semibold text-blue-600">"Completar con IA"</span> para rellenar automáticamente.
+              Responde Sí o No a cada pregunta. Puedes usar{' '}
+              <span className="font-semibold text-blue-600">"Completar con IA"</span> para rellenar
+              automáticamente.
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <Form {...form}>
-              <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
-                {/* Step 1: System Type */}
-                {currentStep === 1 && (
-                  <div className="space-y-4">
-                    <div>
-                      <h3 className="font-semibold text-gray-900 flex items-center gap-2 mb-1">
-                        <span className="w-6 h-6 rounded-full bg-blue-100 text-blue-600 text-sm flex items-center justify-center font-bold">1</span>
-                        Tipo de Sistema de IA
-                      </h3>
-                      <p className="text-sm text-gray-500 ml-8">Si usas un modelo de terceros vía API (OpenAI, Anthropic, Google…), selecciona según la aplicación que construyes, no según el modelo base.</p>
-                    </div>
-                    <FormField control={form.control} name="systemType" render={({ field }) => (
-                      <FormItem>
-                        <FormControl>
-                          <div className="grid grid-cols-1 gap-3">
-                            {systemTypes.map((type) => {
-                              const Icon = type.icon;
-                              const isSelected = field.value === type.value;
-                              return (
-                                <button key={type.value} type="button" onClick={() => field.onChange(type.value)}
-                                  className={`flex items-start gap-4 p-5 rounded-xl border-2 text-left transition-all hover:shadow-md ${isSelected ? 'border-blue-500 bg-blue-50' : 'border-gray-200 bg-white hover:border-gray-300'}`}>
-                                  <div className={`p-3 rounded-xl shrink-0 ${isSelected ? 'bg-blue-100' : 'bg-gray-100'}`}>
-                                    <Icon className={`w-6 h-6 ${isSelected ? 'text-blue-600' : 'text-gray-500'}`} />
-                                  </div>
-                                  <div className="flex-1">
-                                    <div className="flex items-center gap-2 flex-wrap">
-                                      <span className="font-semibold text-gray-900 text-base">{type.label}</span>
-                                      {type.badge && <Badge variant="secondary" className="text-xs">{type.badge}</Badge>}
-                                      <InfoTooltip text={type.tooltip} />
-                                    </div>
-                                    <div className="text-sm text-gray-600 mt-1 leading-relaxed">{type.description}</div>
-                                    <div className="text-xs text-blue-600 mt-2 font-medium">{type.examples}</div>
-                                  </div>
-                                  {isSelected && <CheckCircle2 className="w-6 h-6 text-blue-500 shrink-0" />}
-                                </button>
-                              );
-                            })}
-                          </div>
-                        </FormControl>
-                      </FormItem>
-                    )} />
-                  </div>
-                )}
+            <div className="space-y-8">
+              {template ? (
+                <RiaFormRenderer
+                  template={template}
+                  answers={answers}
+                  currentStep={currentStep}
+                  aiFilledFields={aiFilledFields}
+                  isAiFilling={isAiFilling}
+                  onChange={handleAnswerChange}
+                />
+              ) : (
+                <p className="text-sm text-gray-500 text-center py-8">
+                  No se pudo cargar la plantilla de evaluación.
+                </p>
+              )}
 
-                {/* Step 2: Article 5 — Prohibited */}
-                {currentStep === 2 && (
-                  <div className="space-y-4">
-                    <div>
-                      <div className="flex items-center gap-2 mb-1">
-                        <h3 className="font-semibold text-red-900 flex items-center gap-2">
-                          <span className="w-6 h-6 rounded-full bg-red-100 text-red-600 text-sm flex items-center justify-center font-bold">2</span>
-                          Usos Prohibidos (Art. 5)
-                        </h3>
-                        <Badge className="bg-red-100 text-red-800 border-red-200 text-xs">Cualquier Sí → Prohibido</Badge>
-                      </div>
-                      <p className="text-sm text-gray-500 ml-8">Si cualquier respuesta es Sí, el sistema está prohibido en la UE. Aplica a todos los tipos de sistema.</p>
-                    </div>
-                    <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-                      <p className="text-sm text-red-800"><AlertCircle className="w-4 h-4 inline mr-1" /><strong>Atención:</strong> Si alguna de estas prácticas aplica a tu sistema, está prohibido en la UE.</p>
-                    </div>
-                    <div className="space-y-3">
-                      <SectionDivider title="Sección A: Manipulación y explotación" />
-                      <FormField control={form.control} name="p2_1" render={({ field }) => (
-                        <FormItem><FormControl>
-                          <YesNoSelector value={field.value} onChange={field.onChange}
-                            label="2.1 — ¿El sistema intenta influir en el comportamiento de las personas sin que sean conscientes, o aprovecha sus puntos débiles para perjudicarlas?"
-                            tooltip="El AI Act prohíbe dos técnicas distintas: (1) técnicas subliminales que operan fuera de la consciencia del usuario; y (2) técnicas que explotan vulnerabilidades específicas —edad, discapacidad, situación económica— para distorsionar la conducta causando daño. Si tu sistema optimiza métricas de engagement sin considerar el impacto en el usuario, puede entrar en esta categoría."
-                            isAiFilling={isAiFilling} aiFilled={aiFilledFields.has('p2_1')} />
-                        </FormControl></FormItem>
-                      )} />
-                      <FormField control={form.control} name="p2_2" render={({ field }) => (
-                        <FormItem><FormControl>
-                          <YesNoSelector value={field.value} onChange={field.onChange}
-                            label="2.2 — ¿El sistema puntúa o clasifica a personas por su comportamiento para conceder o denegar beneficios en contextos no relacionados con esa puntuación?"
-                            tooltip="La prohibición de 'social scoring' se refiere a usar IA para construir perfiles de comportamiento social que luego se usen en contextos distintos al que generó los datos. No confundir con el scoring crediticio tradicional basado en historial financiero (que es Alto Riesgo, no Prohibido)."
-                            isAiFilling={isAiFilling} aiFilled={aiFilledFields.has('p2_2')} />
-                        </FormControl></FormItem>
-                      )} />
-                      <SectionDivider title="Sección B: Vigilancia y biometría" />
-                      <FormField control={form.control} name="p2_3" render={({ field }) => (
-                        <FormItem><FormControl>
-                          <YesNoSelector value={field.value} onChange={field.onChange}
-                            label="2.3 — ¿El sistema identifica personas a distancia y en tiempo real en espacios públicos mediante biometría, con fines de vigilancia policial?"
-                            tooltip="Se refiere a la identificación biométrica remota en tiempo real: el sistema procesa rasgos físicos de personas en espacios accesibles al público para contrastarlos con bases de datos, mientras ocurre. Esta prohibición tiene tres excepciones muy estrictas — si crees que tu sistema podría acogerse a alguna, responde Sí y se desplegará la subpregunta."
-                            isAiFilling={isAiFilling} aiFilled={aiFilledFields.has('p2_3')} />
-                        </FormControl></FormItem>
-                      )} />
-                      {p2_3Value === 'yes' && (
-                        <div className="ml-6 border-l-2 border-orange-200 pl-4">
-                          <FormField control={form.control} name="p2_3a" render={({ field }) => (
-                            <FormItem><FormControl>
-                              <YesNoSelector value={field.value} onChange={field.onChange}
-                                label="2.3a — ¿Opera exclusivamente bajo autorización judicial para búsqueda de víctimas de trata, prevención de ataque terrorista inminente o localización de sospechosos de delitos graves?"
-                                tooltip="Las tres únicas excepciones requieren: (1) autorización judicial previa, (2) que el uso sea estrictamente necesario, y (3) que existan las salvaguardas procedimentales exigidas. Si se cumple todo → no es Prohibido, pero sí es Alto Riesgo. Si hay cualquier duda, consulta con asesoría legal."
-                                isAiFilling={isAiFilling} aiFilled={aiFilledFields.has('p2_3a')} />
-                            </FormControl></FormItem>
-                          )} />
-                        </div>
-                      )}
-                      <FormField control={form.control} name="p2_4" render={({ field }) => (
-                        <FormItem><FormControl>
-                          <YesNoSelector value={field.value} onChange={field.onChange}
-                            label="2.4 — ¿El sistema deduce rasgos sensibles —raza, ideología política, religión u orientación sexual— a partir de datos biométricos?"
-                            tooltip="Esta prohibición cubre los sistemas que usan datos biométricos (imagen, voz, movimiento, señales fisiológicas) para inferir atributos especialmente protegidos. No requiere que la inferencia sea correcta — el mero intento de deducir estos atributos es suficiente para la prohibición."
-                            isAiFilling={isAiFilling} aiFilled={aiFilledFields.has('p2_4')} />
-                        </FormControl></FormItem>
-                      )} />
-                      <FormField control={form.control} name="p2_5" render={({ field }) => (
-                        <FormItem><FormControl>
-                          <YesNoSelector value={field.value} onChange={field.onChange}
-                            label="2.5 — ¿El sistema recopila imágenes de rostros de forma masiva desde internet o cámaras para crear o ampliar bases de datos de reconocimiento facial?"
-                            tooltip="La prohibición cubre tanto el scraping desde fuentes abiertas (redes sociales, webs públicas) como la captura desde sistemas de videovigilancia, siempre que el fin sea construir o ampliar bases de datos de reconocimiento facial. La mera recopilación masiva con esta finalidad está prohibida."
-                            isAiFilling={isAiFilling} aiFilled={aiFilledFields.has('p2_5')} />
-                        </FormControl></FormItem>
-                      )} />
-                      <FormField control={form.control} name="p2_6" render={({ field }) => (
-                        <FormItem><FormControl>
-                          <YesNoSelector value={field.value} onChange={field.onChange}
-                            label="2.6 — ¿El sistema detecta o infiere las emociones de empleados o estudiantes en el contexto laboral o educativo?"
-                            tooltip="El AI Act prohíbe la inferencia de emociones en el lugar de trabajo y en centros educativos. No aplica si la finalidad es exclusivamente médica o de seguridad y está debidamente documentada. Si hay una relación de dependencia o evaluación, aplica la prohibición."
-                            isAiFilling={isAiFilling} aiFilled={aiFilledFields.has('p2_6')} />
-                        </FormControl></FormItem>
-                      )} />
-                    </div>
-                  </div>
+              <div className="flex justify-between pt-4">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setCurrentStep((s) => Math.max(1, s - 1))}
+                  disabled={currentStep === 1}
+                >
+                  Anterior
+                </Button>
+                {currentStep < totalSteps ? (
+                  <Button type="button" onClick={() => setCurrentStep((s) => Math.min(s + 1, totalSteps))}>
+                    Siguiente
+                  </Button>
+                ) : (
+                  <Button
+                    type="button"
+                    onClick={handleSubmit}
+                    disabled={calculating || !finalStepReady || !template}
+                  >
+                    {calculating ? 'Calculando...' : 'Finalizar Clasificación'}
+                  </Button>
                 )}
-
-                {/* Step 3: Annex III — only for non-GPAI */}
-                {currentStep === 3 && !isGPAI && (
-                  <div className="space-y-4">
-                    <div>
-                      <div className="flex items-center gap-2 mb-1">
-                        <h3 className="font-semibold text-orange-900 flex items-center gap-2">
-                          <span className="w-6 h-6 rounded-full bg-orange-100 text-orange-600 text-sm flex items-center justify-center font-bold">3</span>
-                          Sistemas de Alto Riesgo (Art. 6 y Anexo III)
-                        </h3>
-                        <InfoTooltip text="El Anexo III del AI Act lista nueve categorías de sistemas considerados de alto riesgo. Un Sí en cualquier pregunta activa los requisitos del Capítulo III: gestión de riesgos, calidad de datos, documentación técnica, supervisión humana y registro en la base de datos UE." />
-                      </div>
-                      <p className="text-sm text-gray-500 ml-8">Si cualquier respuesta es Sí, el sistema se clasifica como Alto Riesgo salvo que se aplique la excepción de la Sección 2 del Art. 6.</p>
-                    </div>
-                    <div className="bg-orange-50 border border-orange-200 rounded-lg p-4">
-                      <p className="text-sm text-orange-800"><AlertTriangle className="w-4 h-4 inline mr-1" /><strong>Importante:</strong> Estos sistemas requieren gestión de riesgos, supervisión humana, documentación técnica y registro en la base de datos de la UE.</p>
-                    </div>
-                    <div className="space-y-3">
-                      <SectionDivider title="Biometría" />
-                      <FormField control={form.control} name="p3_1" render={({ field }) => (
-                        <FormItem><FormControl>
-                          <YesNoSelector value={field.value} onChange={field.onChange}
-                            label="3.1 — ¿El sistema realiza identificación biométrica remota en diferido (no en tiempo real) de personas?"
-                            tooltip="La identificación biométrica remota post-facto consiste en cotejar grabaciones o imágenes ya obtenidas contra bases de datos, sin hacerlo en el momento de la captura. Es Alto Riesgo (no Prohibido) cuando no se hace en tiempo real."
-                            isAiFilling={isAiFilling} aiFilled={aiFilledFields.has('p3_1')} />
-                        </FormControl></FormItem>
-                      )} />
-                      <FormField control={form.control} name="p3_2" render={({ field }) => (
-                        <FormItem><FormControl>
-                          <YesNoSelector value={field.value} onChange={field.onChange}
-                            label="3.2 — ¿El sistema categoriza personas por características biométricas para inferir raza, opinión política, sindicación, religión, vida u orientación sexual?"
-                            tooltip="La categorización biométrica sensible va más allá de la identificación: infiere atributos especialmente protegidos. No confundir con la prohibición (p2_4): aquí aplica cuando el uso es legítimo pero la materia es sensible, lo que lo convierte en Alto Riesgo."
-                            isAiFilling={isAiFilling} aiFilled={aiFilledFields.has('p3_2')} />
-                        </FormControl></FormItem>
-                      )} />
-                      <FormField control={form.control} name="p3_3" render={({ field }) => (
-                        <FormItem><FormControl>
-                          <YesNoSelector value={field.value} onChange={field.onChange}
-                            label="3.3 — ¿El sistema detecta, reconoce o verifica emociones de personas?"
-                            tooltip="La detección de emociones mediante biometría (expresión facial, tono de voz, microgestos) es Alto Riesgo cuando no opera en el ámbito laboral o educativo (donde sería Prohibida). Por ejemplo, en atención al cliente, banca o seguros puede ser Alto Riesgo."
-                            isAiFilling={isAiFilling} aiFilled={aiFilledFields.has('p3_3')} />
-                        </FormControl></FormItem>
-                      )} />
-                      {p3_3Value === 'yes' && (
-                        <div className="ml-6 border-l-2 border-orange-200 pl-4">
-                          <FormField control={form.control} name="p3_3a" render={({ field }) => (
-                            <FormItem><FormControl>
-                              <YesNoSelector value={field.value} onChange={field.onChange}
-                                label="3.3a — ¿Se usa exclusivamente con finalidad médica o de seguridad debidamente documentada?"
-                                tooltip="Si la detección de emociones tiene una finalidad exclusivamente médica (p.ej., monitorización de pacientes) o de seguridad (p.ej., detección de fatiga en conductores) y está debidamente justificada y documentada, se aplica una excepción que puede reducir su clasificación."
-                                isAiFilling={isAiFilling} aiFilled={aiFilledFields.has('p3_3a')} />
-                            </FormControl></FormItem>
-                          )} />
-                        </div>
-                      )}
-                      <SectionDivider title="Infraestructuras y seguridad" />
-                      <FormField control={form.control} name="p3_4" render={({ field }) => (
-                        <FormItem><FormControl>
-                          <YesNoSelector value={field.value} onChange={field.onChange}
-                            label="3.4 — ¿El sistema gestiona o controla infraestructura crítica (redes eléctricas, agua, gas, transporte o sistemas financieros)?"
-                            tooltip="Infraestructura crítica es aquella cuya interrupción tendría consecuencias graves para la seguridad pública, la economía o servicios esenciales. Si el sistema toma decisiones automatizadas que afectan a estos entornos, se clasifica como Alto Riesgo."
-                            isAiFilling={isAiFilling} aiFilled={aiFilledFields.has('p3_4')} />
-                        </FormControl></FormItem>
-                      )} />
-                      <FormField control={form.control} name="p3_5" render={({ field }) => (
-                        <FormItem><FormControl>
-                          <YesNoSelector value={field.value} onChange={field.onChange}
-                            label="3.5 — ¿El sistema es un componente de seguridad de un producto regulado por legislación sectorial de la UE (Anexo I del AI Act)?"
-                            tooltip="El Anexo I del AI Act lista sectores con legislación de armonización preexistente: maquinaria industrial, juguetes, equipos de radio, equipos de presión, vehículos a motor, dispositivos médicos, equipos de protección individual, entre otros. Si tu sistema de IA actúa como componente de seguridad de estos productos, es Alto Riesgo."
-                            isAiFilling={isAiFilling} aiFilled={aiFilledFields.has('p3_5')} />
-                        </FormControl></FormItem>
-                      )} />
-                      <SectionDivider title="Derechos fundamentales y acceso a servicios" />
-                      <FormField control={form.control} name="p3_6" render={({ field }) => (
-                        <FormItem><FormControl>
-                          <YesNoSelector value={field.value} onChange={field.onChange}
-                            label="3.6 — ¿El sistema determina el acceso a educación, formación profesional, o evalúa el rendimiento académico?"
-                            tooltip="Sistemas que deciden quién accede a instituciones educativas, qué trayectorias formativas se recomiendan, o que evalúan el rendimiento de estudiantes. Incluye plataformas de evaluación adaptativa, sistemas de admisión y herramientas de detección de plagio que determinan sanciones."
-                            isAiFilling={isAiFilling} aiFilled={aiFilledFields.has('p3_6')} />
-                        </FormControl></FormItem>
-                      )} />
-                      <FormField control={form.control} name="p3_7" render={({ field }) => (
-                        <FormItem><FormControl>
-                          <YesNoSelector value={field.value} onChange={field.onChange}
-                            label="3.7 — ¿El sistema interviene en reclutamiento, selección, evaluación o gestión de personas en el empleo?"
-                            tooltip="Aplica a la IA que filtra CVs, puntúa candidatos, decide ascensos o despidos, asigna tareas, monitoriza productividad o determina condiciones laborales. La presencia de supervisión humana no excluye la clasificación como Alto Riesgo si la IA condiciona las decisiones finales."
-                            isAiFilling={isAiFilling} aiFilled={aiFilledFields.has('p3_7')} />
-                        </FormControl></FormItem>
-                      )} />
-                      <FormField control={form.control} name="p3_8" render={({ field }) => (
-                        <FormItem><FormControl>
-                          <YesNoSelector value={field.value} onChange={field.onChange}
-                            label="3.8 — ¿El sistema evalúa la elegibilidad para servicios públicos, prestaciones sociales, créditos, seguros u otros servicios esenciales?"
-                            tooltip="Scoring crediticio, evaluación de riesgo en seguros, valoración de elegibilidad para ayudas sociales, scoring médico para priorización de atención. La clave es si el sistema condiciona de forma significativa el acceso de personas a recursos o servicios esenciales."
-                            isAiFilling={isAiFilling} aiFilled={aiFilledFields.has('p3_8')} />
-                        </FormControl></FormItem>
-                      )} />
-                      <SectionDivider title="Orden público y justicia" />
-                      <FormField control={form.control} name="p3_9" render={({ field }) => (
-                        <FormItem><FormControl>
-                          <YesNoSelector value={field.value} onChange={field.onChange}
-                            label="3.9 — ¿El sistema apoya decisiones en las áreas de aplicación de la ley, gestión migratoria, asilo, control de fronteras, administración de justicia o procesos democráticos?"
-                            tooltip="Esta categoría agrupa los tres últimos grupos del Anexo III: (6) aplicación de la ley — análisis de riesgo de reincidencia, perfilado, poligrafía; (7) migración y asilo — valoración de solicitudes, detección de documentos fraudulentos; (8) administración de justicia — asistencia a jueces; y (9) procesos democráticos — influencia en elecciones o referéndums."
-                            isAiFilling={isAiFilling} aiFilled={aiFilledFields.has('p3_9')} />
-                        </FormControl></FormItem>
-                      )} />
-                    </div>
-                  </div>
-                )}
-
-                {/* Step 3/4: Article 50 Transparency — step 3 for GPAI, step 4 for non-GPAI */}
-                {((currentStep === 3 && isGPAI) || (currentStep === 4 && !isGPAI)) && (
-                  <div className="space-y-4">
-                    <div>
-                      <h3 className="font-semibold text-yellow-900 flex items-center gap-2 mb-1">
-                        <span className="w-6 h-6 rounded-full bg-yellow-100 text-yellow-600 text-sm flex items-center justify-center font-bold">{isGPAI ? '3' : '4'}</span>
-                        Obligaciones de Transparencia (Art. 50)
-                      </h3>
-                      <p className="text-sm text-gray-500 ml-8">Un Sí activa la obligación de transparencia pero no cambia el nivel de riesgo principal. Puede coexistir con cualquier clasificación.</p>
-                    </div>
-                    <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
-                      <p className="text-sm text-yellow-800"><Shield className="w-4 h-4 inline mr-1" /><strong>Transparencia obligatoria:</strong> Estos sistemas deben informar activamente a los usuarios de que interactúan con IA o de que el contenido es sintético.</p>
-                    </div>
-                    <div className="space-y-3">
-                      <FormField control={form.control} name="p4_1" render={({ field }) => (
-                        <FormItem><FormControl>
-                          <YesNoSelector value={field.value} onChange={field.onChange}
-                            label="4.1 — ¿El sistema interactúa directamente con personas sin que sea evidente que están ante una IA (chatbots, agentes conversacionales)?"
-                            tooltip="La obligación aplica cuando un usuario podría creer razonablemente que está interactuando con una persona humana. No aplica si el uso de IA es obvio por el contexto o si el usuario ya fue informado. Incluye chatbots de atención al cliente, asistentes virtuales y agentes autónomos."
-                            isAiFilling={isAiFilling} aiFilled={aiFilledFields.has('p4_1')} />
-                        </FormControl></FormItem>
-                      )} />
-                      <FormField control={form.control} name="p4_2" render={({ field }) => (
-                        <FormItem><FormControl>
-                          <YesNoSelector value={field.value} onChange={field.onChange}
-                            label="4.2 — ¿El sistema genera contenido sintético de imagen, audio o vídeo que representa personas, lugares o eventos reales (deepfakes)?"
-                            tooltip="La obligación de marcar el contenido como generado por IA aplica a los contenidos que podrían inducir a error sobre su autenticidad. Se excluyen los usos artísticos o de entretenimiento que lo anuncien claramente. El foco es en la capacidad de confusión con la realidad."
-                            isAiFilling={isAiFilling} aiFilled={aiFilledFields.has('p4_2')} />
-                        </FormControl></FormItem>
-                      )} />
-                      <FormField control={form.control} name="p4_3" render={({ field }) => (
-                        <FormItem><FormControl>
-                          <YesNoSelector value={field.value} onChange={field.onChange}
-                            label="4.3 — ¿El sistema genera textos publicados sobre materias de interés público sin revelar que son generados por IA?"
-                            tooltip="Aplica a sistemas que producen contenido informativo, periodístico o de análisis de actualidad que podría presentarse al público sin indicar su origen artificial. El objetivo es prevenir la desinformación a escala."
-                            isAiFilling={isAiFilling} aiFilled={aiFilledFields.has('p4_3')} />
-                        </FormControl></FormItem>
-                      )} />
-                      <FormField control={form.control} name="p4_4" render={({ field }) => (
-                        <FormItem><FormControl>
-                          <YesNoSelector value={field.value} onChange={field.onChange}
-                            label="4.4 — ¿El sistema detecta o infiere emociones de personas (fuera del ámbito laboral/educativo prohibido)?"
-                            tooltip="La detección de emociones en contextos no prohibidos (ver 2.6) activa la obligación de informar al afectado. Por ejemplo, en atención al cliente o en aplicaciones de salud mental. Debe notificarse al usuario antes o en el momento en que se produce la detección."
-                            isAiFilling={isAiFilling} aiFilled={aiFilledFields.has('p4_4')} />
-                        </FormControl></FormItem>
-                      )} />
-                    </div>
-                  </div>
-                )}
-
-                {/* Navigation */}
-                <div className="flex justify-between pt-4">
-                  <Button type="button" variant="outline" onClick={() => setCurrentStep(Math.max(1, currentStep - 1))} disabled={currentStep === 1}>Anterior</Button>
-                  {currentStep < totalSteps ? (
-                    <Button type="button" onClick={handleNextStep}>Siguiente</Button>
-                  ) : (
-                    <Button type="submit" disabled={calculating || !finalStepReady}>{calculating ? 'Calculando...' : 'Finalizar Clasificación'}</Button>
-                  )}
-                </div>
-              </form>
-            </Form>
+              </div>
+            </div>
           </CardContent>
         </Card>
       </div>
 
-      {/* AI Chat Drawer — opens when AI needs clarification */}
       {showChat && (
         <div className="fixed bottom-4 right-4 w-[420px] max-h-[600px] bg-white rounded-2xl shadow-2xl border border-gray-200 z-50 flex flex-col overflow-hidden animate-in slide-in-from-bottom-4 duration-300">
           <div className="flex items-center justify-between px-4 py-3 bg-gradient-to-r from-blue-600 to-indigo-600 text-white">
@@ -821,18 +478,22 @@ export default function ClassifyUseCasePage() {
               <MessageSquare className="w-4 h-4" />
               <span className="font-semibold text-sm">Asistente AI Act</span>
             </div>
-            <button onClick={() => setShowChat(false)} className="hover:bg-white/20 rounded-lg p-1 transition-colors">
+            <button
+              onClick={() => setShowChat(false)}
+              className="hover:bg-white/20 rounded-lg p-1 transition-colors"
+            >
               <X className="w-4 h-4" />
             </button>
           </div>
           <div className="flex-1 overflow-y-auto p-4">
             <AIClassificationAssistant
-              systemName={useCase?.name}
-              systemDescription={useCase?.description}
+              systemName={String(useCase?.name ?? '')}
+              systemDescription={String(useCase?.description ?? '')}
               initialQuestions={unclearQuestions}
               onClassificationSuggested={(classification) => {
-                // Apply classification result to form
-                toast.success('Clasificación aplicada', { description: `Nivel: ${riskLevels[classification.level as keyof typeof riskLevels]?.label ?? classification.level}` });
+                toast.success('Clasificación aplicada', {
+                  description: `Nivel: ${riskLevels[classification.level as keyof typeof riskLevels]?.label ?? classification.level}`,
+                });
                 setShowChat(false);
               }}
             />

--- a/apps/web/app/api/v1/ai-systems/[id]/ria-template/route.ts
+++ b/apps/web/app/api/v1/ai-systems/[id]/ria-template/route.ts
@@ -1,0 +1,93 @@
+import { createClient } from '@/lib/supabase/server';
+import { NextRequest, NextResponse } from 'next/server';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  try {
+    const supabase = await createClient();
+    const { id: aiSystemId } = await params;
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { data: assignment } = await supabase
+      .from('ai_system_ria_assignments')
+      .select('template_id, ria_form_templates(*)')
+      .eq('ai_system_id', aiSystemId)
+      .single();
+
+    if (assignment?.ria_form_templates) {
+      return NextResponse.json({ success: true, data: assignment.ria_form_templates });
+    }
+
+    const { data: defaultTemplate } = await supabase
+      .from('ria_form_templates')
+      .select('*')
+      .eq('is_default', true)
+      .order('is_system', { ascending: false })
+      .limit(1)
+      .single();
+
+    if (defaultTemplate) {
+      return NextResponse.json({ success: true, data: defaultTemplate });
+    }
+
+    const { data: systemTemplate } = await supabase
+      .from('ria_form_templates')
+      .select('*')
+      .eq('is_system', true)
+      .limit(1)
+      .single();
+
+    return NextResponse.json({ success: true, data: systemTemplate ?? null });
+  } catch {
+    return NextResponse.json({ success: false, error: 'Error interno del servidor' }, { status: 500 });
+  }
+}
+
+export async function PUT(request: NextRequest, { params }: RouteParams) {
+  try {
+    const supabase = await createClient();
+    const { id: aiSystemId } = await params;
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { template_id } = await request.json();
+    if (!template_id) {
+      return NextResponse.json({ success: false, error: 'template_id es obligatorio' }, { status: 400 });
+    }
+
+    const { data: template, error: templateError } = await supabase
+      .from('ria_form_templates')
+      .select('id')
+      .eq('id', template_id)
+      .single();
+
+    if (templateError || !template) {
+      return NextResponse.json({ success: false, error: 'Plantilla no encontrada' }, { status: 404 });
+    }
+
+    const { error: upsertError } = await supabase
+      .from('ai_system_ria_assignments')
+      .upsert(
+        { ai_system_id: aiSystemId, template_id },
+        { onConflict: 'ai_system_id' }
+      );
+
+    if (upsertError) {
+      return NextResponse.json({ success: false, error: 'Error al asignar la plantilla' }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true, data: { ai_system_id: aiSystemId, template_id } });
+  } catch {
+    return NextResponse.json({ success: false, error: 'Error interno del servidor' }, { status: 500 });
+  }
+}

--- a/apps/web/app/api/v1/ria-templates/[id]/duplicate/route.ts
+++ b/apps/web/app/api/v1/ria-templates/[id]/duplicate/route.ts
@@ -1,0 +1,71 @@
+import { createClient } from '@/lib/supabase/server';
+import { requirePermission } from '@/lib/supabase/get-user-role';
+import { NextRequest, NextResponse } from 'next/server';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const supabase = await createClient();
+    const { id } = await params;
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const permCheck = await requirePermission(supabase, user.id, 'templates:manage');
+    if (!permCheck.allowed) {
+      return NextResponse.json({ success: false, error: 'Sin permisos para gestionar plantillas' }, { status: 403 });
+    }
+
+    const { name } = await request.json();
+    if (!name?.trim()) {
+      return NextResponse.json({ success: false, error: 'El nombre es obligatorio' }, { status: 400 });
+    }
+
+    const { data: source, error: sourceError } = await supabase
+      .from('ria_form_templates')
+      .select('*')
+      .eq('id', id)
+      .single();
+
+    if (sourceError || !source) {
+      return NextResponse.json({ success: false, error: 'Plantilla origen no encontrada' }, { status: 404 });
+    }
+
+    const { data: membership } = await supabase
+      .from('organization_members')
+      .select('organization_id')
+      .eq('user_id', user.id)
+      .eq('status', 'active')
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .single();
+
+    const { data: newTemplate, error: insertError } = await supabase
+      .from('ria_form_templates')
+      .insert({
+        name: name.trim(),
+        description: source.description,
+        is_system: false,
+        is_default: false,
+        organization_id: membership?.organization_id ?? null,
+        created_by: user.id,
+        structure: source.structure,
+        classification_rules: source.classification_rules,
+      })
+      .select()
+      .single();
+
+    if (insertError) {
+      return NextResponse.json({ success: false, error: 'Error al duplicar la plantilla' }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true, data: newTemplate }, { status: 201 });
+  } catch {
+    return NextResponse.json({ success: false, error: 'Error interno del servidor' }, { status: 500 });
+  }
+}

--- a/apps/web/app/api/v1/ria-templates/[id]/route.ts
+++ b/apps/web/app/api/v1/ria-templates/[id]/route.ts
@@ -1,0 +1,163 @@
+import { createClient } from '@/lib/supabase/server';
+import { requirePermission } from '@/lib/supabase/get-user-role';
+import { NextRequest, NextResponse } from 'next/server';
+import type { UpdateRiaTemplatePayload } from '@/types/ria-form-template';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  try {
+    const supabase = await createClient();
+    const { id } = await params;
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { data: template, error } = await supabase
+      .from('ria_form_templates')
+      .select('*')
+      .eq('id', id)
+      .single();
+
+    if (error || !template) {
+      return NextResponse.json({ success: false, error: 'Plantilla no encontrada' }, { status: 404 });
+    }
+
+    return NextResponse.json({ success: true, data: template });
+  } catch {
+    return NextResponse.json({ success: false, error: 'Error interno del servidor' }, { status: 500 });
+  }
+}
+
+export async function PUT(request: NextRequest, { params }: RouteParams) {
+  try {
+    const supabase = await createClient();
+    const { id } = await params;
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const permCheck = await requirePermission(supabase, user.id, 'templates:manage');
+    if (!permCheck.allowed) {
+      return NextResponse.json({ success: false, error: 'Sin permisos para gestionar plantillas' }, { status: 403 });
+    }
+
+    const { data: existing, error: fetchError } = await supabase
+      .from('ria_form_templates')
+      .select('*')
+      .eq('id', id)
+      .single();
+
+    if (fetchError || !existing) {
+      return NextResponse.json({ success: false, error: 'Plantilla no encontrada' }, { status: 404 });
+    }
+
+    if (existing.is_system) {
+      return NextResponse.json(
+        { success: false, error: 'Las plantillas del sistema no se pueden modificar' },
+        { status: 403 }
+      );
+    }
+
+    const body: UpdateRiaTemplatePayload = await request.json();
+    const updateData: Record<string, unknown> = {};
+
+    if (body.name !== undefined) updateData.name = body.name.trim();
+    if (body.description !== undefined) updateData.description = body.description?.trim() ?? null;
+    if (body.structure !== undefined) updateData.structure = body.structure;
+    if (body.classification_rules !== undefined) updateData.classification_rules = body.classification_rules;
+
+    if (body.is_default === true) {
+      const { error: clearError } = await supabase
+        .from('ria_form_templates')
+        .update({ is_default: false })
+        .eq('organization_id', existing.organization_id)
+        .eq('is_default', true);
+
+      if (clearError) {
+        return NextResponse.json({ success: false, error: 'Error al actualizar plantilla por defecto' }, { status: 500 });
+      }
+
+      updateData.is_default = true;
+    }
+
+    if (Object.keys(updateData).length === 0) {
+      return NextResponse.json({ success: true, data: existing });
+    }
+
+    const { data: updated, error: updateError } = await supabase
+      .from('ria_form_templates')
+      .update(updateData)
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (updateError) {
+      return NextResponse.json({ success: false, error: 'Error al actualizar la plantilla' }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true, data: updated });
+  } catch {
+    return NextResponse.json({ success: false, error: 'Error interno del servidor' }, { status: 500 });
+  }
+}
+
+export async function DELETE(_request: NextRequest, { params }: RouteParams) {
+  try {
+    const supabase = await createClient();
+    const { id } = await params;
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const permCheck = await requirePermission(supabase, user.id, 'templates:manage');
+    if (!permCheck.allowed) {
+      return NextResponse.json({ success: false, error: 'Sin permisos para gestionar plantillas' }, { status: 403 });
+    }
+
+    const { data: existing, error: fetchError } = await supabase
+      .from('ria_form_templates')
+      .select('id, is_system, is_default')
+      .eq('id', id)
+      .single();
+
+    if (fetchError || !existing) {
+      return NextResponse.json({ success: false, error: 'Plantilla no encontrada' }, { status: 404 });
+    }
+
+    if (existing.is_system) {
+      return NextResponse.json(
+        { success: false, error: 'Las plantillas del sistema no se pueden eliminar' },
+        { status: 403 }
+      );
+    }
+
+    if (existing.is_default) {
+      return NextResponse.json(
+        { success: false, error: 'No se puede eliminar la plantilla por defecto. Establece otra como predeterminada primero.' },
+        { status: 400 }
+      );
+    }
+
+    const { error: deleteError } = await supabase
+      .from('ria_form_templates')
+      .delete()
+      .eq('id', id);
+
+    if (deleteError) {
+      return NextResponse.json({ success: false, error: 'Error al eliminar la plantilla' }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true, data: null });
+  } catch {
+    return NextResponse.json({ success: false, error: 'Error interno del servidor' }, { status: 500 });
+  }
+}

--- a/apps/web/app/api/v1/ria-templates/[id]/set-default/route.ts
+++ b/apps/web/app/api/v1/ria-templates/[id]/set-default/route.ts
@@ -1,0 +1,64 @@
+import { createClient } from '@/lib/supabase/server';
+import { requirePermission } from '@/lib/supabase/get-user-role';
+import { NextRequest, NextResponse } from 'next/server';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function POST(_request: NextRequest, { params }: RouteParams) {
+  try {
+    const supabase = await createClient();
+    const { id } = await params;
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const permCheck = await requirePermission(supabase, user.id, 'templates:manage');
+    if (!permCheck.allowed) {
+      return NextResponse.json({ success: false, error: 'Sin permisos para gestionar plantillas' }, { status: 403 });
+    }
+
+    const { data: template, error: fetchError } = await supabase
+      .from('ria_form_templates')
+      .select('id, organization_id, is_system')
+      .eq('id', id)
+      .single();
+
+    if (fetchError || !template) {
+      return NextResponse.json({ success: false, error: 'Plantilla no encontrada' }, { status: 404 });
+    }
+
+    if (template.organization_id) {
+      await supabase
+        .from('ria_form_templates')
+        .update({ is_default: false })
+        .eq('organization_id', template.organization_id)
+        .eq('is_default', true);
+    } else if (template.is_system) {
+      await supabase
+        .from('ria_form_templates')
+        .update({ is_default: false })
+        .is('organization_id', null)
+        .eq('is_default', true);
+    }
+
+    const { error: setError } = await supabase
+      .from('ria_form_templates')
+      .update({ is_default: true })
+      .eq('id', id);
+
+    if (setError) {
+      return NextResponse.json(
+        { success: false, error: 'Error al establecer la plantilla por defecto' },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ success: true, data: null });
+  } catch {
+    return NextResponse.json({ success: false, error: 'Error interno del servidor' }, { status: 500 });
+  }
+}

--- a/apps/web/app/api/v1/ria-templates/route.ts
+++ b/apps/web/app/api/v1/ria-templates/route.ts
@@ -1,0 +1,110 @@
+import { createClient } from '@/lib/supabase/server';
+import { requirePermission } from '@/lib/supabase/get-user-role';
+import { NextRequest, NextResponse } from 'next/server';
+import type { CreateRiaTemplatePayload } from '@/types/ria-form-template';
+
+export async function GET() {
+  try {
+    const supabase = await createClient();
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { data: templates, error } = await supabase
+      .from('ria_form_templates')
+      .select('*')
+      .order('is_system', { ascending: false })
+      .order('is_default', { ascending: false })
+      .order('name');
+
+    if (error) {
+      return NextResponse.json({ success: false, error: 'Error al cargar plantillas' }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true, data: templates });
+  } catch {
+    return NextResponse.json({ success: false, error: 'Error interno del servidor' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const permCheck = await requirePermission(supabase, user.id, 'templates:manage');
+    if (!permCheck.allowed) {
+      return NextResponse.json({ success: false, error: 'Sin permisos para gestionar plantillas' }, { status: 403 });
+    }
+
+    const body: CreateRiaTemplatePayload = await request.json();
+    const { name, description, structure, classification_rules, source_template_id } = body;
+
+    if (!name?.trim()) {
+      return NextResponse.json({ success: false, error: 'El nombre es obligatorio' }, { status: 400 });
+    }
+
+    let finalStructure = structure;
+    let finalRules = classification_rules;
+
+    if (source_template_id) {
+      const { data: source, error: sourceError } = await supabase
+        .from('ria_form_templates')
+        .select('structure, classification_rules')
+        .eq('id', source_template_id)
+        .single();
+
+      if (sourceError || !source) {
+        return NextResponse.json({ success: false, error: 'Plantilla origen no encontrada' }, { status: 404 });
+      }
+
+      finalStructure = structure ?? source.structure;
+      finalRules = classification_rules ?? source.classification_rules;
+    }
+
+    if (!finalStructure || !finalRules) {
+      return NextResponse.json(
+        { success: false, error: 'La estructura y las reglas de clasificación son obligatorias' },
+        { status: 400 }
+      );
+    }
+
+    const { data: membership } = await supabase
+      .from('organization_members')
+      .select('organization_id')
+      .eq('user_id', user.id)
+      .eq('status', 'active')
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .single();
+
+    const { data: template, error: insertError } = await supabase
+      .from('ria_form_templates')
+      .insert({
+        name: name.trim(),
+        description: description?.trim() ?? null,
+        is_system: false,
+        is_default: false,
+        organization_id: membership?.organization_id ?? null,
+        created_by: user.id,
+        structure: finalStructure,
+        classification_rules: finalRules,
+      })
+      .select()
+      .single();
+
+    if (insertError) {
+      return NextResponse.json({ success: false, error: 'Error al crear la plantilla' }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true, data: template }, { status: 201 });
+  } catch {
+    return NextResponse.json({ success: false, error: 'Error interno del servidor' }, { status: 500 });
+  }
+}

--- a/apps/web/components/ria-form-renderer.tsx
+++ b/apps/web/components/ria-form-renderer.tsx
@@ -1,0 +1,311 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { HelpCircle, CheckCircle2, Sparkles, Brain, Cpu, Bot } from 'lucide-react';
+import type {
+  RiaFormTemplate,
+  RiaFormStep,
+  RiaFormQuestion,
+  RiaFormAnswers,
+  SystemTypeValue,
+} from '@/types/ria-form-template';
+
+// ── InfoTooltip ───────────────────────────────────────────────────────────────
+
+function InfoTooltip({ text }: { text: string }) {
+  const [show, setShow] = useState(false);
+  const [position, setPosition] = useState<'top' | 'bottom'>('top');
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (show && containerRef.current) {
+      const rect = containerRef.current.getBoundingClientRect();
+      if (rect.top < 150 && window.innerHeight - rect.bottom > 150) setPosition('bottom');
+      else setPosition('top');
+    }
+  }, [show]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative inline-flex items-center ml-2"
+      onMouseEnter={() => setShow(true)}
+      onMouseLeave={() => setShow(false)}
+    >
+      <HelpCircle className="w-4 h-4 text-gray-400 cursor-help hover:text-blue-500 transition-colors" />
+      {show && (
+        <div
+          className={`absolute ${position === 'top' ? 'bottom-full mb-3' : 'top-full mt-3'} left-1/2 -translate-x-1/2 px-4 py-3 bg-gray-900 text-white text-sm rounded-xl shadow-2xl z-[9999] w-80 leading-relaxed pointer-events-none`}
+        >
+          {text}
+          <div
+            className={`absolute left-1/2 -translate-x-1/2 w-0 h-0 border-x-8 border-x-transparent ${position === 'top' ? 'top-full border-t-8 border-t-gray-900' : 'bottom-full border-b-8 border-b-gray-900'}`}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── SectionDivider ────────────────────────────────────────────────────────────
+
+function SectionDivider({ title }: { title: string }) {
+  return (
+    <div className="flex items-center gap-3 py-1">
+      <div className="h-px flex-1 bg-gray-200" />
+      <span className="text-xs font-semibold text-gray-500 uppercase tracking-wider">{title}</span>
+      <div className="h-px flex-1 bg-gray-200" />
+    </div>
+  );
+}
+
+// ── YesNoQuestion ─────────────────────────────────────────────────────────────
+
+function YesNoQuestion({
+  question,
+  value,
+  onChange,
+  isAiFilling,
+  aiFilled,
+}: {
+  question: RiaFormQuestion;
+  value: string;
+  onChange: (key: string, val: 'yes' | 'no') => void;
+  isAiFilling?: boolean;
+  aiFilled?: boolean;
+}) {
+  return (
+    <div
+      className={`relative rounded-xl border-2 p-4 transition-all cursor-pointer ${
+        aiFilled
+          ? 'border-blue-300 bg-blue-50/50'
+          : 'border-gray-100 hover:border-blue-200 hover:bg-blue-50/30'
+      }`}
+      onClick={() => onChange(question.key, value === 'yes' ? 'no' : 'yes')}
+    >
+      {isAiFilling && (
+        <div className="absolute inset-0 overflow-hidden rounded-xl pointer-events-none">
+          <div className="h-full bg-gradient-to-r from-blue-100/0 via-blue-200/60 to-blue-100/0 animate-[shimmer_1.5s_ease-in-out_infinite]" />
+        </div>
+      )}
+      <div className="flex items-center justify-between gap-4 relative z-10">
+        <div className="flex items-center gap-2 flex-1">
+          <span className="font-medium text-gray-900 text-sm">{question.label}</span>
+          {question.tooltip && <InfoTooltip text={question.tooltip} />}
+        </div>
+        <div className="flex gap-2 shrink-0" onClick={(e) => e.stopPropagation()}>
+          <button
+            type="button"
+            onClick={() => onChange(question.key, 'yes')}
+            className={`px-5 py-2 rounded-lg font-semibold text-sm transition-all ${
+              value === 'yes'
+                ? 'bg-green-500 text-white shadow-md ring-2 ring-green-200'
+                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+            }`}
+          >
+            Sí
+          </button>
+          <button
+            type="button"
+            onClick={() => onChange(question.key, 'no')}
+            className={`px-5 py-2 rounded-lg font-semibold text-sm transition-all ${
+              value === 'no'
+                ? 'bg-gray-500 text-white shadow-md ring-2 ring-gray-300'
+                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+            }`}
+          >
+            No
+          </button>
+        </div>
+      </div>
+      {aiFilled && (
+        <div className="flex items-center gap-1 mt-2 relative z-10">
+          <Sparkles className="w-3 h-3 text-blue-500" />
+          <span className="text-xs text-blue-600 font-medium">Completado por IA</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── System type icons ─────────────────────────────────────────────────────────
+
+const SYSTEM_TYPE_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
+  gpai: Brain,
+  gpai_base: Brain,
+  gpai_systemic: Brain,
+  non_gpai_standalone: Cpu,
+  specific: Cpu,
+  non_gpai_embedded: Bot,
+  multipurpose: Bot,
+  unsure: HelpCircle,
+};
+
+// ── SystemTypeStep ────────────────────────────────────────────────────────────
+
+function SystemTypeStep({
+  step,
+  answers,
+  onChange,
+}: {
+  step: RiaFormStep;
+  answers: RiaFormAnswers;
+  onChange: (key: string, value: string) => void;
+}) {
+  const current = answers['systemType'] ?? '';
+
+  return (
+    <div className="space-y-3">
+      {(step.options ?? []).map((option) => {
+        const Icon = SYSTEM_TYPE_ICONS[option.value] ?? Cpu;
+        const isSelected = current === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onChange('systemType', option.value)}
+            className={`flex items-start gap-4 p-5 rounded-xl border-2 text-left w-full transition-all hover:shadow-md ${
+              isSelected ? 'border-blue-500 bg-blue-50' : 'border-gray-200 bg-white hover:border-gray-300'
+            }`}
+          >
+            <div className={`p-3 rounded-xl shrink-0 ${isSelected ? 'bg-blue-100' : 'bg-gray-100'}`}>
+              <Icon className={`w-6 h-6 ${isSelected ? 'text-blue-600' : 'text-gray-500'}`} />
+            </div>
+            <div className="flex-1">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="font-semibold text-gray-900 text-base">{option.label}</span>
+                {option.description && (
+                  <span className="text-sm text-gray-600">{option.description}</span>
+                )}
+              </div>
+            </div>
+            {isSelected && <CheckCircle2 className="w-6 h-6 text-blue-500 shrink-0" />}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── QuestionsStep ─────────────────────────────────────────────────────────────
+
+function QuestionsStep({
+  step,
+  answers,
+  onChange,
+  aiFilledFields,
+  isAiFilling,
+}: {
+  step: RiaFormStep;
+  answers: RiaFormAnswers;
+  onChange: (key: string, value: string) => void;
+  aiFilledFields: Set<string>;
+  isAiFilling: boolean;
+}) {
+  return (
+    <div className="space-y-6">
+      {(step.sections ?? []).map((section) => {
+        const visibleQuestions = section.questions.filter((q) => {
+          if (!q.parent_question_id) return true;
+          return answers[q.parent_question_id] === q.parent_answer_trigger;
+        });
+
+        if (visibleQuestions.length === 0) return null;
+
+        return (
+          <div key={section.id} className="space-y-3">
+            <SectionDivider title={section.title} />
+            {visibleQuestions.map((question) => (
+              <YesNoQuestion
+                key={question.id}
+                question={question}
+                value={answers[question.key] ?? 'no'}
+                onChange={onChange}
+                isAiFilling={isAiFilling}
+                aiFilled={aiFilledFields.has(question.key)}
+              />
+            ))}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── RiaFormRenderer ───────────────────────────────────────────────────────────
+
+interface Props {
+  template: RiaFormTemplate;
+  answers: RiaFormAnswers;
+  currentStep: number;
+  aiFilledFields: Set<string>;
+  isAiFilling: boolean;
+  onChange: (key: string, value: string) => void;
+}
+
+export function RiaFormRenderer({
+  template,
+  answers,
+  currentStep,
+  aiFilledFields,
+  isAiFilling,
+  onChange,
+}: Props) {
+  const systemTypeValue = answers['systemType'] as SystemTypeValue | undefined;
+  const isGpai = systemTypeValue === 'gpai';
+
+  const steps = template.structure.steps.filter((step) => {
+    if (!step.applies_to || step.applies_to === 'all') return true;
+    if (step.applies_to === 'non_gpai') return !isGpai;
+    if (step.applies_to === 'gpai') return isGpai;
+    return true;
+  });
+
+  const step = steps[currentStep - 1];
+  if (!step) return null;
+
+  if (step.type === 'system_type') {
+    return <SystemTypeStep step={step} answers={answers} onChange={onChange} />;
+  }
+
+  return (
+    <QuestionsStep
+      step={step}
+      answers={answers}
+      onChange={onChange}
+      aiFilledFields={aiFilledFields}
+      isAiFilling={isAiFilling}
+    />
+  );
+}
+
+export function getRiaStepCount(template: RiaFormTemplate, answers: RiaFormAnswers): number {
+  const systemTypeValue = answers['systemType'] as SystemTypeValue | undefined;
+  const isGpai = systemTypeValue === 'gpai';
+
+  return template.structure.steps.filter((step) => {
+    if (!step.applies_to || step.applies_to === 'all') return true;
+    if (step.applies_to === 'non_gpai') return !isGpai;
+    if (step.applies_to === 'gpai') return isGpai;
+    return true;
+  }).length;
+}
+
+export function getRiaStepTitle(
+  template: RiaFormTemplate,
+  answers: RiaFormAnswers,
+  stepIndex: number
+): string {
+  const systemTypeValue = answers['systemType'] as SystemTypeValue | undefined;
+  const isGpai = systemTypeValue === 'gpai';
+
+  const steps = template.structure.steps.filter((step) => {
+    if (!step.applies_to || step.applies_to === 'all') return true;
+    if (step.applies_to === 'non_gpai') return !isGpai;
+    if (step.applies_to === 'gpai') return isGpai;
+    return true;
+  });
+
+  return steps[stepIndex - 1]?.title ?? '';
+}

--- a/apps/web/hooks/use-ria-templates.ts
+++ b/apps/web/hooks/use-ria-templates.ts
@@ -1,0 +1,122 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import type {
+  RiaFormTemplate,
+  CreateRiaTemplatePayload,
+  UpdateRiaTemplatePayload,
+} from '@/types/ria-form-template';
+
+interface UseRiaTemplatesReturn {
+  templates: RiaFormTemplate[];
+  isLoading: boolean;
+  error: string | null;
+  createTemplate: (payload: CreateRiaTemplatePayload) => Promise<RiaFormTemplate>;
+  updateTemplate: (id: string, payload: UpdateRiaTemplatePayload) => Promise<RiaFormTemplate>;
+  deleteTemplate: (id: string) => Promise<void>;
+  duplicateTemplate: (id: string, name: string) => Promise<RiaFormTemplate>;
+  setDefaultTemplate: (id: string) => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+export function useRiaTemplates(): UseRiaTemplatesReturn {
+  const [templates, setTemplates] = useState<RiaFormTemplate[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchTemplates = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/v1/ria-templates');
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error ?? 'Error al cargar plantillas');
+      setTemplates(json.data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error desconocido');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchTemplates();
+  }, [fetchTemplates]);
+
+  const createTemplate = useCallback(
+    async (payload: CreateRiaTemplatePayload): Promise<RiaFormTemplate> => {
+      const res = await fetch('/api/v1/ria-templates', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error ?? 'Error al crear plantilla');
+      await fetchTemplates();
+      return json.data;
+    },
+    [fetchTemplates]
+  );
+
+  const updateTemplate = useCallback(
+    async (id: string, payload: UpdateRiaTemplatePayload): Promise<RiaFormTemplate> => {
+      const res = await fetch(`/api/v1/ria-templates/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error ?? 'Error al actualizar plantilla');
+      await fetchTemplates();
+      return json.data;
+    },
+    [fetchTemplates]
+  );
+
+  const deleteTemplate = useCallback(
+    async (id: string): Promise<void> => {
+      const res = await fetch(`/api/v1/ria-templates/${id}`, { method: 'DELETE' });
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error ?? 'Error al eliminar plantilla');
+      await fetchTemplates();
+    },
+    [fetchTemplates]
+  );
+
+  const duplicateTemplate = useCallback(
+    async (id: string, name: string): Promise<RiaFormTemplate> => {
+      const res = await fetch(`/api/v1/ria-templates/${id}/duplicate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name }),
+      });
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error ?? 'Error al duplicar plantilla');
+      await fetchTemplates();
+      return json.data;
+    },
+    [fetchTemplates]
+  );
+
+  const setDefaultTemplate = useCallback(
+    async (id: string): Promise<void> => {
+      const res = await fetch(`/api/v1/ria-templates/${id}/set-default`, { method: 'POST' });
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error ?? 'Error al establecer plantilla por defecto');
+      await fetchTemplates();
+    },
+    [fetchTemplates]
+  );
+
+  return {
+    templates,
+    isLoading,
+    error,
+    createTemplate,
+    updateTemplate,
+    deleteTemplate,
+    duplicateTemplate,
+    setDefaultTemplate,
+    refresh: fetchTemplates,
+  };
+}

--- a/apps/web/lib/utils/ria-classification.ts
+++ b/apps/web/lib/utils/ria-classification.ts
@@ -1,0 +1,55 @@
+import type {
+  RiaClassificationRules,
+  RiaCondition,
+  RiaFormAnswers,
+  RiskLevel,
+} from '@/types/ria-form-template';
+
+function evaluateCondition(condition: RiaCondition, answers: RiaFormAnswers): boolean {
+  if (condition.type === 'field_equals') {
+    return answers[condition.field] === condition.value;
+  }
+
+  if (condition.type === 'all') {
+    return condition.conditions.every((c) => evaluateCondition(c, answers));
+  }
+
+  if (condition.type === 'any') {
+    return condition.conditions.some((c) => evaluateCondition(c, answers));
+  }
+
+  return false;
+}
+
+export function evaluateRiaClassification(
+  rules: RiaClassificationRules,
+  answers: RiaFormAnswers
+): RiskLevel {
+  for (const riskLevel of rules.priority) {
+    const rule = rules.rules.find((r) => r.result === riskLevel);
+    if (!rule) continue;
+
+    const topLevelConditions =
+      rule.logic === 'all'
+        ? rule.conditions.every((c) => evaluateCondition(c, answers))
+        : rule.conditions.some((c) => evaluateCondition(c, answers));
+
+    if (topLevelConditions) {
+      return riskLevel;
+    }
+  }
+
+  return rules.default_result;
+}
+
+export function evaluateTransparencyRequired(
+  rules: RiaClassificationRules,
+  answers: RiaFormAnswers
+): boolean {
+  const { transparency_rules } = rules;
+  if (!transparency_rules?.conditions?.length) return false;
+
+  return transparency_rules.logic === 'all'
+    ? transparency_rules.conditions.every((c) => evaluateCondition(c, answers))
+    : transparency_rules.conditions.some((c) => evaluateCondition(c, answers));
+}

--- a/apps/web/types/ria-form-template.ts
+++ b/apps/web/types/ria-form-template.ts
@@ -1,0 +1,137 @@
+export type RiskLevel =
+  | 'prohibited'
+  | 'high_risk'
+  | 'gpai_regime'
+  | 'limited_risk'
+  | 'minimal_risk';
+
+export type SystemTypeValue =
+  | 'gpai'
+  | 'non_gpai_embedded'
+  | 'non_gpai_standalone'
+  | 'unsure';
+
+// --- Form Structure Types ---
+
+export interface RiaSystemTypeOption {
+  value: SystemTypeValue;
+  label: string;
+  description?: string;
+}
+
+export interface RiaFormQuestion {
+  id: string;
+  key: string;
+  label: string;
+  tooltip?: string;
+  affects_classification: boolean;
+  parent_question_id: string | null;
+  parent_answer_trigger: string | null;
+  options?: Array<{ value: string; label: string }>;
+}
+
+export interface RiaFormSection {
+  id: string;
+  title: string;
+  description?: string;
+  questions: RiaFormQuestion[];
+}
+
+export interface RiaFormStep {
+  id: string;
+  title: string;
+  subtitle?: string;
+  type: 'system_type' | 'questions';
+  applies_to?: 'all' | 'non_gpai' | 'gpai';
+  options?: RiaSystemTypeOption[];
+  sections?: RiaFormSection[];
+}
+
+export interface RiaFormStructure {
+  version: string;
+  steps: RiaFormStep[];
+}
+
+// --- Classification Rules Types ---
+
+export interface FieldEqualsCondition {
+  type: 'field_equals';
+  field: string;
+  value: string;
+}
+
+export interface AllCondition {
+  type: 'all';
+  conditions: RiaCondition[];
+}
+
+export interface AnyCondition {
+  type: 'any';
+  conditions: RiaCondition[];
+}
+
+export type RiaCondition = FieldEqualsCondition | AllCondition | AnyCondition;
+
+export interface RiaClassificationRule {
+  result: RiskLevel;
+  logic: 'all' | 'any';
+  conditions: RiaCondition[];
+}
+
+export interface RiaTransparencyRule {
+  logic: 'all' | 'any';
+  conditions: RiaCondition[];
+}
+
+export interface RiaClassificationRules {
+  version: string;
+  rules: RiaClassificationRule[];
+  transparency_rules: RiaTransparencyRule;
+  priority: RiskLevel[];
+  default_result: RiskLevel;
+}
+
+// --- Template Record Types ---
+
+export interface RiaFormTemplate {
+  id: string;
+  name: string;
+  description?: string;
+  is_system: boolean;
+  is_default: boolean;
+  organization_id: string | null;
+  created_by: string | null;
+  structure: RiaFormStructure;
+  classification_rules: RiaClassificationRules;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AiSystemRiaAssignment {
+  ai_system_id: string;
+  template_id: string;
+  created_at: string;
+  updated_at: string;
+}
+
+// --- API Payload Types ---
+
+export interface CreateRiaTemplatePayload {
+  name: string;
+  description?: string;
+  structure: RiaFormStructure;
+  classification_rules: RiaClassificationRules;
+  source_template_id?: string;
+}
+
+export interface UpdateRiaTemplatePayload {
+  name?: string;
+  description?: string;
+  structure?: RiaFormStructure;
+  classification_rules?: RiaClassificationRules;
+  is_default?: boolean;
+}
+
+// --- Form Answers ---
+
+export type RiaFormAnswers = Record<string, string>;

--- a/supabase/migrations/20260425000000_create_ria_form_templates.sql
+++ b/supabase/migrations/20260425000000_create_ria_form_templates.sql
@@ -1,0 +1,587 @@
+-- RIA Form Templates
+-- Stores dynamic questionnaire templates for EU AI Act risk classification
+
+CREATE TABLE ria_form_templates (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  name text NOT NULL,
+  description text,
+  is_system boolean DEFAULT false NOT NULL,
+  is_default boolean DEFAULT false NOT NULL,
+  organization_id uuid REFERENCES organizations(id) ON DELETE CASCADE,
+  created_by uuid REFERENCES auth.users(id),
+  structure jsonb NOT NULL DEFAULT '{}',
+  classification_rules jsonb NOT NULL DEFAULT '{}',
+  created_at timestamptz DEFAULT now() NOT NULL,
+  updated_at timestamptz DEFAULT now() NOT NULL
+);
+
+-- Only one default per organization (NULL org = system-level default)
+CREATE UNIQUE INDEX ria_templates_one_org_default
+  ON ria_form_templates (organization_id)
+  WHERE is_default = true AND organization_id IS NOT NULL;
+
+CREATE UNIQUE INDEX ria_templates_one_system_default
+  ON ria_form_templates ((true))
+  WHERE is_default = true AND is_system = true;
+
+-- Per-system template assignment (overrides the default)
+CREATE TABLE ai_system_ria_assignments (
+  ai_system_id uuid PRIMARY KEY REFERENCES use_cases(id) ON DELETE CASCADE,
+  template_id uuid NOT NULL REFERENCES ria_form_templates(id) ON DELETE RESTRICT,
+  created_at timestamptz DEFAULT now() NOT NULL,
+  updated_at timestamptz DEFAULT now() NOT NULL
+);
+
+-- Updated_at triggers
+CREATE OR REPLACE FUNCTION update_ria_form_templates_updated_at()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER ria_form_templates_updated_at
+  BEFORE UPDATE ON ria_form_templates
+  FOR EACH ROW EXECUTE FUNCTION update_ria_form_templates_updated_at();
+
+CREATE OR REPLACE FUNCTION update_ai_system_ria_assignments_updated_at()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER ai_system_ria_assignments_updated_at
+  BEFORE UPDATE ON ai_system_ria_assignments
+  FOR EACH ROW EXECUTE FUNCTION update_ai_system_ria_assignments_updated_at();
+
+-- RLS
+ALTER TABLE ria_form_templates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ai_system_ria_assignments ENABLE ROW LEVEL SECURITY;
+
+-- System templates are readable by everyone
+CREATE POLICY "system_templates_readable_by_all" ON ria_form_templates
+  FOR SELECT USING (is_system = true);
+
+-- Org templates readable by org members
+CREATE POLICY "org_templates_readable_by_members" ON ria_form_templates
+  FOR SELECT USING (
+    organization_id IS NOT NULL AND
+    organization_id IN (
+      SELECT om.organization_id FROM organization_members om
+      WHERE om.user_id = auth.uid() AND om.status = 'active'
+    )
+  );
+
+-- Own templates readable by creator (solo users)
+CREATE POLICY "own_templates_readable" ON ria_form_templates
+  FOR SELECT USING (
+    organization_id IS NULL AND created_by = auth.uid()
+  );
+
+-- Only org admins/owners can insert templates
+CREATE POLICY "org_admins_can_insert_templates" ON ria_form_templates
+  FOR INSERT WITH CHECK (
+    NOT is_system AND (
+      -- Solo user
+      organization_id IS NULL AND created_by = auth.uid()
+      OR
+      -- Org member with admin+
+      organization_id IN (
+        SELECT om.organization_id FROM organization_members om
+        WHERE om.user_id = auth.uid()
+          AND om.status = 'active'
+          AND om.role IN ('owner', 'admin')
+      )
+    )
+  );
+
+-- Only owners of templates can update (not system templates)
+CREATE POLICY "template_owners_can_update" ON ria_form_templates
+  FOR UPDATE USING (
+    NOT is_system AND (
+      created_by = auth.uid()
+      OR organization_id IN (
+        SELECT om.organization_id FROM organization_members om
+        WHERE om.user_id = auth.uid()
+          AND om.status = 'active'
+          AND om.role IN ('owner', 'admin')
+      )
+    )
+  );
+
+-- Only owners can delete custom templates
+CREATE POLICY "template_owners_can_delete" ON ria_form_templates
+  FOR DELETE USING (
+    NOT is_system AND (
+      created_by = auth.uid()
+      OR organization_id IN (
+        SELECT om.organization_id FROM organization_members om
+        WHERE om.user_id = auth.uid()
+          AND om.status = 'active'
+          AND om.role IN ('owner', 'admin')
+      )
+    )
+  );
+
+-- RIA assignments: accessible to system owners
+CREATE POLICY "ria_assignments_select" ON ai_system_ria_assignments
+  FOR SELECT USING (
+    ai_system_id IN (
+      SELECT id FROM use_cases
+      WHERE user_id = auth.uid()
+        OR organization_id IN (
+          SELECT om.organization_id FROM organization_members om
+          WHERE om.user_id = auth.uid() AND om.status = 'active'
+        )
+    )
+  );
+
+CREATE POLICY "ria_assignments_insert" ON ai_system_ria_assignments
+  FOR INSERT WITH CHECK (
+    ai_system_id IN (
+      SELECT id FROM use_cases
+      WHERE user_id = auth.uid()
+        OR organization_id IN (
+          SELECT om.organization_id FROM organization_members om
+          WHERE om.user_id = auth.uid() AND om.status = 'active'
+            AND om.role IN ('owner', 'admin', 'editor')
+        )
+    )
+  );
+
+CREATE POLICY "ria_assignments_update" ON ai_system_ria_assignments
+  FOR UPDATE USING (
+    ai_system_id IN (
+      SELECT id FROM use_cases
+      WHERE user_id = auth.uid()
+        OR organization_id IN (
+          SELECT om.organization_id FROM organization_members om
+          WHERE om.user_id = auth.uid() AND om.status = 'active'
+            AND om.role IN ('owner', 'admin', 'editor')
+        )
+    )
+  );
+
+CREATE POLICY "ria_assignments_delete" ON ai_system_ria_assignments
+  FOR DELETE USING (
+    ai_system_id IN (
+      SELECT id FROM use_cases
+      WHERE user_id = auth.uid()
+        OR organization_id IN (
+          SELECT om.organization_id FROM organization_members om
+          WHERE om.user_id = auth.uid() AND om.status = 'active'
+            AND om.role IN ('owner', 'admin', 'editor')
+        )
+    )
+  );
+
+-- ─── Seed the system template ────────────────────────────────────────────────
+
+INSERT INTO ria_form_templates (
+  id,
+  name,
+  description,
+  is_system,
+  is_default,
+  organization_id,
+  created_by,
+  structure,
+  classification_rules
+) VALUES (
+  '00000000-0000-0000-0000-000000000001',
+  'Plantilla EU AI Act (Sistema)',
+  'Cuestionario oficial de clasificación de riesgo según el Reglamento (UE) 2024/1689 (AI Act). Cubre: tipo de sistema, usos prohibidos (Art. 5), sistemas de alto riesgo (Anexo III) y obligaciones de transparencia (Art. 50).',
+  true,
+  true,
+  null,
+  null,
+  '{
+    "version": "1.0",
+    "steps": [
+      {
+        "id": "step-1",
+        "key": "systemType",
+        "title": "Tipo de Sistema de IA",
+        "description": "Si usas un modelo de terceros vía API (OpenAI, Anthropic, Google…), selecciona según la aplicación que construyes, no según el modelo base.",
+        "type": "system_type",
+        "step_order": 1,
+        "applies_to": "all",
+        "options": [
+          {
+            "value": "gpai_base",
+            "label": "Modelo GPAI",
+            "description": "Entreno y distribuyo un modelo base sin interfaz ni caso de uso propio",
+            "examples": "LLM propio, modelo de embeddings propietario",
+            "icon": "Brain",
+            "tooltip": "Un modelo GPAI (General Purpose AI) es un modelo entrenado con grandes cantidades de datos que puede realizar múltiples tipos de tareas. Si eres tú quien lo entrena y lo distribuye —sin definir un caso de uso concreto— selecciona esta opción. Si lo que haces es usar un modelo de otro (OpenAI, Anthropic, etc.) para construir tu aplicación, no eres proveedor de un modelo GPAI."
+          },
+          {
+            "value": "gpai_systemic",
+            "label": "Modelo GPAI de alto impacto",
+            "description": "Mi modelo supera 10²⁵ FLOP de entrenamiento o ha sido designado por la Comisión Europea",
+            "examples": "Modelos frontier de grandes laboratorios de IA",
+            "icon": "Sparkles",
+            "tooltip": "El AI Act define un umbral cuantitativo de 10²⁵ FLOP de cómputo de entrenamiento para considerar un modelo GPAI de riesgo sistémico. También puede ser designado por la Comisión Europea en base a otros criterios como el número de usuarios o capacidades en dominios críticos. Esta categoría aplica a muy pocos actores a nivel mundial."
+          },
+          {
+            "value": "specific",
+            "label": "Sistema con finalidad definida",
+            "description": "Aplico IA a un caso de uso concreto, aunque use un modelo de terceros",
+            "examples": "Chatbot, detector de fraude, scoring de crédito, generador de contratos",
+            "badge": "★ más habitual",
+            "icon": "Cpu",
+            "tooltip": "Es la categoría más frecuente para PYMEs. Si tu sistema tiene un propósito claro y específico —aunque por debajo use GPT-4 u otro modelo— selecciona esta opción. La finalidad concreta es lo que determina el riesgo regulatorio, no el modelo subyacente."
+          },
+          {
+            "value": "multipurpose",
+            "label": "Sistema con múltiples usos",
+            "description": "Mi sistema puede aplicarse a distintos casos de uso sin uno único definido",
+            "examples": "Plataforma de automatización corporativa, asistente IA multiuso interno",
+            "icon": "Bot",
+            "tooltip": "Selecciona esta opción si tu sistema está diseñado para que distintos departamentos o clientes lo usen con finalidades diferentes, sin una única función predefinida. En este caso, el AI Act exige evaluar el riesgo por cada caso de uso concreto. CumplIA te mostrará una advertencia para que repitas la evaluación por cada uso previsto."
+          }
+        ]
+      },
+      {
+        "id": "step-2",
+        "title": "Usos Prohibidos (Art. 5)",
+        "type": "questions",
+        "step_order": 2,
+        "applies_to": "all",
+        "badge_text": "Cualquier Sí → Prohibido",
+        "badge_color": "red",
+        "warning_message": "Si cualquier respuesta es Sí, el sistema está prohibido en la UE. Aplica a todos los tipos de sistema.",
+        "warning_type": "danger",
+        "sections": [
+          {
+            "id": "section-2-a",
+            "title": "Sección A: Manipulación y explotación",
+            "section_order": 1,
+            "questions": [
+              {
+                "id": "q-p2-1",
+                "key": "p2_1",
+                "label": "2.1 — ¿El sistema intenta influir en el comportamiento de las personas sin que sean conscientes, o aprovecha sus puntos débiles para perjudicarlas?",
+                "tooltip": "El AI Act prohíbe dos técnicas distintas: (1) técnicas subliminales que operan fuera de la consciencia del usuario; y (2) técnicas que explotan vulnerabilidades específicas —edad, discapacidad, situación económica— para distorsionar la conducta causando daño. Si tu sistema optimiza métricas de engagement sin considerar el impacto en el usuario, puede entrar en esta categoría.",
+                "question_order": 1,
+                "affects_classification": true
+              },
+              {
+                "id": "q-p2-2",
+                "key": "p2_2",
+                "label": "2.2 — ¿El sistema puntúa o clasifica a personas por su comportamiento para conceder o denegar beneficios en contextos no relacionados con esa puntuación?",
+                "tooltip": "La prohibición de social scoring se refiere a usar IA para construir perfiles de comportamiento social que luego se usen en contextos distintos al que generó los datos. No confundir con el scoring crediticio tradicional basado en historial financiero (que es Alto Riesgo, no Prohibido).",
+                "question_order": 2,
+                "affects_classification": true
+              }
+            ]
+          },
+          {
+            "id": "section-2-b",
+            "title": "Sección B: Vigilancia y biometría",
+            "section_order": 2,
+            "questions": [
+              {
+                "id": "q-p2-3",
+                "key": "p2_3",
+                "label": "2.3 — ¿El sistema identifica personas a distancia y en tiempo real en espacios públicos mediante biometría, con fines de vigilancia policial?",
+                "tooltip": "Se refiere a la identificación biométrica remota en tiempo real: el sistema procesa rasgos físicos de personas en espacios accesibles al público para contrastarlos con bases de datos, mientras ocurre. Esta prohibición tiene tres excepciones muy estrictas — si crees que tu sistema podría acogerse a alguna, responde Sí y se desplegará la subpregunta.",
+                "question_order": 1,
+                "affects_classification": true
+              },
+              {
+                "id": "q-p2-3a",
+                "key": "p2_3a",
+                "label": "2.3a — ¿Opera exclusivamente bajo autorización judicial para búsqueda de víctimas de trata, prevención de ataque terrorista inminente o localización de sospechosos de delitos graves?",
+                "tooltip": "Las tres únicas excepciones requieren: (1) autorización judicial previa, (2) que el uso sea estrictamente necesario, y (3) que existan las salvaguardas procedimentales exigidas. Si se cumple todo → no es Prohibido, pero sí es Alto Riesgo. Si hay cualquier duda, consulta con asesoría legal.",
+                "question_order": 2,
+                "affects_classification": true,
+                "parent_question_id": "q-p2-3",
+                "parent_answer_trigger": "yes"
+              },
+              {
+                "id": "q-p2-4",
+                "key": "p2_4",
+                "label": "2.4 — ¿El sistema deduce rasgos sensibles —raza, ideología política, religión u orientación sexual— a partir de datos biométricos?",
+                "tooltip": "Esta prohibición cubre los sistemas que usan datos biométricos (imagen, voz, movimiento, señales fisiológicas) para inferir atributos especialmente protegidos. No requiere que la inferencia sea correcta — el mero intento de deducir estos atributos es suficiente para la prohibición.",
+                "question_order": 3,
+                "affects_classification": true
+              },
+              {
+                "id": "q-p2-5",
+                "key": "p2_5",
+                "label": "2.5 — ¿El sistema recopila imágenes de rostros de forma masiva desde internet o cámaras para crear o ampliar bases de datos de reconocimiento facial?",
+                "tooltip": "La prohibición cubre tanto el scraping desde fuentes abiertas (redes sociales, webs públicas) como la captura desde sistemas de videovigilancia, siempre que el fin sea construir o ampliar bases de datos de reconocimiento facial. La mera recopilación masiva con esta finalidad está prohibida.",
+                "question_order": 4,
+                "affects_classification": true
+              },
+              {
+                "id": "q-p2-6",
+                "key": "p2_6",
+                "label": "2.6 — ¿El sistema detecta o infiere las emociones de empleados o estudiantes en el contexto laboral o educativo?",
+                "tooltip": "El AI Act prohíbe la inferencia de emociones en el lugar de trabajo y en centros educativos. No aplica si la finalidad es exclusivamente médica o de seguridad y está debidamente documentada. Si hay una relación de dependencia o evaluación, aplica la prohibición.",
+                "question_order": 5,
+                "affects_classification": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "step-3",
+        "title": "Sistemas de Alto Riesgo (Art. 6 y Anexo III)",
+        "type": "questions",
+        "step_order": 3,
+        "applies_to": "non_gpai",
+        "warning_message": "Si cualquier respuesta es Sí, el sistema se clasifica como Alto Riesgo salvo que se aplique la excepción de la Sección 2 del Art. 6.",
+        "warning_type": "warning",
+        "sections": [
+          {
+            "id": "section-3-biometry",
+            "title": "Biometría",
+            "section_order": 1,
+            "questions": [
+              {
+                "id": "q-p3-1",
+                "key": "p3_1",
+                "label": "3.1 — ¿El sistema realiza identificación biométrica remota en diferido (no en tiempo real) de personas?",
+                "tooltip": "La identificación biométrica remota post-facto consiste en cotejar grabaciones o imágenes ya obtenidas contra bases de datos, sin hacerlo en el momento de la captura. Es Alto Riesgo (no Prohibido) cuando no se hace en tiempo real.",
+                "question_order": 1,
+                "affects_classification": true
+              },
+              {
+                "id": "q-p3-2",
+                "key": "p3_2",
+                "label": "3.2 — ¿El sistema categoriza personas por características biométricas para inferir raza, opinión política, sindicación, religión, vida u orientación sexual?",
+                "tooltip": "La categorización biométrica sensible va más allá de la identificación: infiere atributos especialmente protegidos. No confundir con la prohibición (p2_4): aquí aplica cuando el uso es legítimo pero la materia es sensible, lo que lo convierte en Alto Riesgo.",
+                "question_order": 2,
+                "affects_classification": true
+              },
+              {
+                "id": "q-p3-3",
+                "key": "p3_3",
+                "label": "3.3 — ¿El sistema detecta, reconoce o verifica emociones de personas?",
+                "tooltip": "La detección de emociones mediante biometría (expresión facial, tono de voz, microgestos) es Alto Riesgo cuando no opera en el ámbito laboral o educativo (donde sería Prohibida). Por ejemplo, en atención al cliente, banca o seguros puede ser Alto Riesgo.",
+                "question_order": 3,
+                "affects_classification": true
+              },
+              {
+                "id": "q-p3-3a",
+                "key": "p3_3a",
+                "label": "3.3a — ¿Se usa exclusivamente con finalidad médica o de seguridad debidamente documentada?",
+                "tooltip": "Si la detección de emociones tiene una finalidad exclusivamente médica (p.ej., monitorización de pacientes) o de seguridad (p.ej., detección de fatiga en conductores) y está debidamente justificada y documentada, se aplica una excepción que puede reducir su clasificación.",
+                "question_order": 4,
+                "affects_classification": true,
+                "parent_question_id": "q-p3-3",
+                "parent_answer_trigger": "yes"
+              }
+            ]
+          },
+          {
+            "id": "section-3-infra",
+            "title": "Infraestructuras y seguridad",
+            "section_order": 2,
+            "questions": [
+              {
+                "id": "q-p3-4",
+                "key": "p3_4",
+                "label": "3.4 — ¿El sistema gestiona o controla infraestructura crítica (redes eléctricas, agua, gas, transporte o sistemas financieros)?",
+                "tooltip": "Infraestructura crítica es aquella cuya interrupción tendría consecuencias graves para la seguridad pública, la economía o servicios esenciales. Si el sistema toma decisiones automatizadas que afectan a estos entornos, se clasifica como Alto Riesgo.",
+                "question_order": 1,
+                "affects_classification": true
+              },
+              {
+                "id": "q-p3-5",
+                "key": "p3_5",
+                "label": "3.5 — ¿El sistema es un componente de seguridad de un producto regulado por legislación sectorial de la UE (Anexo I del AI Act)?",
+                "tooltip": "El Anexo I del AI Act lista sectores con legislación de armonización preexistente: maquinaria industrial, juguetes, equipos de radio, equipos de presión, vehículos a motor, dispositivos médicos, equipos de protección individual, entre otros. Si tu sistema de IA actúa como componente de seguridad de estos productos, es Alto Riesgo.",
+                "question_order": 2,
+                "affects_classification": true
+              }
+            ]
+          },
+          {
+            "id": "section-3-rights",
+            "title": "Derechos fundamentales y acceso a servicios",
+            "section_order": 3,
+            "questions": [
+              {
+                "id": "q-p3-6",
+                "key": "p3_6",
+                "label": "3.6 — ¿El sistema determina el acceso a educación, formación profesional, o evalúa el rendimiento académico?",
+                "tooltip": "Sistemas que deciden quién accede a instituciones educativas, qué trayectorias formativas se recomiendan, o que evalúan el rendimiento de estudiantes. Incluye plataformas de evaluación adaptativa, sistemas de admisión y herramientas de detección de plagio que determinan sanciones.",
+                "question_order": 1,
+                "affects_classification": true
+              },
+              {
+                "id": "q-p3-7",
+                "key": "p3_7",
+                "label": "3.7 — ¿El sistema interviene en reclutamiento, selección, evaluación o gestión de personas en el empleo?",
+                "tooltip": "Aplica a la IA que filtra CVs, puntúa candidatos, decide ascensos o despidos, asigna tareas, monitoriza productividad o determina condiciones laborales. La presencia de supervisión humana no excluye la clasificación como Alto Riesgo si la IA condiciona las decisiones finales.",
+                "question_order": 2,
+                "affects_classification": true
+              },
+              {
+                "id": "q-p3-8",
+                "key": "p3_8",
+                "label": "3.8 — ¿El sistema evalúa la elegibilidad para servicios públicos, prestaciones sociales, créditos, seguros u otros servicios esenciales?",
+                "tooltip": "Scoring crediticio, evaluación de riesgo en seguros, valoración de elegibilidad para ayudas sociales, scoring médico para priorización de atención. La clave es si el sistema condiciona de forma significativa el acceso de personas a recursos o servicios esenciales.",
+                "question_order": 3,
+                "affects_classification": true
+              }
+            ]
+          },
+          {
+            "id": "section-3-order",
+            "title": "Orden público y justicia",
+            "section_order": 4,
+            "questions": [
+              {
+                "id": "q-p3-9",
+                "key": "p3_9",
+                "label": "3.9 — ¿El sistema apoya decisiones en las áreas de aplicación de la ley, gestión migratoria, asilo, control de fronteras, administración de justicia o procesos democráticos?",
+                "tooltip": "Esta categoría agrupa los tres últimos grupos del Anexo III: (6) aplicación de la ley — análisis de riesgo de reincidencia, perfilado, poligrafía; (7) migración y asilo — valoración de solicitudes, detección de documentos fraudulentos; (8) administración de justicia — asistencia a jueces; y (9) procesos democráticos — influencia en elecciones o referéndums.",
+                "question_order": 1,
+                "affects_classification": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "step-4",
+        "title": "Obligaciones de Transparencia (Art. 50)",
+        "type": "questions",
+        "step_order": 4,
+        "applies_to": "all",
+        "warning_message": "Un Sí activa la obligación de transparencia pero no cambia el nivel de riesgo principal. Puede coexistir con cualquier clasificación.",
+        "warning_type": "info",
+        "sections": [
+          {
+            "id": "section-4-main",
+            "title": "",
+            "section_order": 1,
+            "questions": [
+              {
+                "id": "q-p4-1",
+                "key": "p4_1",
+                "label": "4.1 — ¿El sistema interactúa directamente con personas sin que sea evidente que están ante una IA (chatbots, agentes conversacionales)?",
+                "tooltip": "La obligación aplica cuando un usuario podría creer razonablemente que está interactuando con una persona humana. No aplica si el uso de IA es obvio por el contexto o si el usuario ya fue informado. Incluye chatbots de atención al cliente, asistentes virtuales y agentes autónomos.",
+                "question_order": 1,
+                "affects_classification": true
+              },
+              {
+                "id": "q-p4-2",
+                "key": "p4_2",
+                "label": "4.2 — ¿El sistema genera contenido sintético de imagen, audio o vídeo que representa personas, lugares o eventos reales (deepfakes)?",
+                "tooltip": "La obligación de marcar el contenido como generado por IA aplica a los contenidos que podrían inducir a error sobre su autenticidad. Se excluyen los usos artísticos o de entretenimiento que lo anuncien claramente. El foco es en la capacidad de confusión con la realidad.",
+                "question_order": 2,
+                "affects_classification": true
+              },
+              {
+                "id": "q-p4-3",
+                "key": "p4_3",
+                "label": "4.3 — ¿El sistema genera textos publicados sobre materias de interés público sin revelar que son generados por IA?",
+                "tooltip": "Aplica a sistemas que producen contenido informativo, periodístico o de análisis de actualidad que podría presentarse al público sin indicar su origen artificial. El objetivo es prevenir la desinformación a escala.",
+                "question_order": 3,
+                "affects_classification": true
+              },
+              {
+                "id": "q-p4-4",
+                "key": "p4_4",
+                "label": "4.4 — ¿El sistema detecta o infiere emociones de personas (fuera del ámbito laboral/educativo prohibido)?",
+                "tooltip": "La detección de emociones en contextos no prohibidos (ver 2.6) activa la obligación de informar al afectado. Por ejemplo, en atención al cliente o en aplicaciones de salud mental. Debe notificarse al usuario antes o en el momento en que se produce la detección.",
+                "question_order": 4,
+                "affects_classification": true
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }',
+  '{
+    "version": "1.0",
+    "rules": [
+      {
+        "result": "prohibited",
+        "logic": "any",
+        "conditions": [
+          {"type": "field_equals", "field": "p2_1", "value": "yes"},
+          {"type": "field_equals", "field": "p2_2", "value": "yes"},
+          {
+            "type": "all",
+            "conditions": [
+              {"type": "field_equals", "field": "p2_3", "value": "yes"},
+              {"type": "field_equals", "field": "p2_3a", "value": "no"}
+            ]
+          },
+          {"type": "field_equals", "field": "p2_4", "value": "yes"},
+          {"type": "field_equals", "field": "p2_5", "value": "yes"},
+          {"type": "field_equals", "field": "p2_6", "value": "yes"}
+        ]
+      },
+      {
+        "result": "high_risk",
+        "logic": "any",
+        "conditions": [
+          {"type": "field_equals", "field": "systemType", "value": "gpai_systemic"},
+          {
+            "type": "all",
+            "conditions": [
+              {"type": "field_equals", "field": "p2_3", "value": "yes"},
+              {"type": "field_equals", "field": "p2_3a", "value": "yes"}
+            ]
+          },
+          {"type": "field_equals", "field": "p3_1", "value": "yes"},
+          {"type": "field_equals", "field": "p3_2", "value": "yes"},
+          {
+            "type": "all",
+            "conditions": [
+              {"type": "field_equals", "field": "p3_3", "value": "yes"},
+              {"type": "field_equals", "field": "p3_3a", "value": "yes"}
+            ]
+          },
+          {"type": "field_equals", "field": "p3_4", "value": "yes"},
+          {"type": "field_equals", "field": "p3_5", "value": "yes"},
+          {"type": "field_equals", "field": "p3_6", "value": "yes"},
+          {"type": "field_equals", "field": "p3_7", "value": "yes"},
+          {"type": "field_equals", "field": "p3_8", "value": "yes"},
+          {"type": "field_equals", "field": "p3_9", "value": "yes"}
+        ]
+      },
+      {
+        "result": "gpai_regime",
+        "logic": "any",
+        "conditions": [
+          {"type": "field_equals", "field": "systemType", "value": "gpai_base"}
+        ]
+      },
+      {
+        "result": "limited_risk",
+        "logic": "any",
+        "conditions": [
+          {"type": "field_equals", "field": "systemType", "value": "multipurpose"},
+          {"type": "field_equals", "field": "p4_1", "value": "yes"},
+          {"type": "field_equals", "field": "p4_2", "value": "yes"},
+          {"type": "field_equals", "field": "p4_3", "value": "yes"},
+          {"type": "field_equals", "field": "p4_4", "value": "yes"}
+        ]
+      }
+    ],
+    "transparency_rules": {
+      "logic": "any",
+      "conditions": [
+        {"type": "field_equals", "field": "p4_1", "value": "yes"},
+        {"type": "field_equals", "field": "p4_2", "value": "yes"},
+        {"type": "field_equals", "field": "p4_3", "value": "yes"},
+        {"type": "field_equals", "field": "p4_4", "value": "yes"}
+      ]
+    },
+    "priority": ["prohibited", "high_risk", "gpai_regime", "limited_risk", "minimal_risk"],
+    "default_result": "minimal_risk"
+  }'
+);


### PR DESCRIPTION
- New `ria_form_templates` and `ai_system_ria_assignments` DB tables with full RLS
- System template seeded with the existing 4-step EU AI Act questionnaire (read-only)
- Per-org custom templates: create, edit, duplicate, set-default, delete
- Template editor: manage steps, sections, questions and affects_classification flag
- Dynamic classification engine (evaluateRiaClassification) replaces hardcoded logic
- Classify page fully data-driven via RiaFormRenderer; per-system template picker
- New admin tab "Formulario RIA" alongside existing Risk Templates and Custom Fields tabs
- API routes: GET/POST /ria-templates, GET/PUT/DELETE /ria-templates/[id], duplicate, set-default, and ai-systems/[id]/ria-template (assignment + fallback chain)